### PR TITLE
AFL capability added to common.sh, corresponding changes to build.sh for LCMS and re2

### DIFF
--- a/boringssl-2016-02-12/build.sh
+++ b/boringssl-2016-02-12/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/boringssl-2016-02-12/build.sh
+++ b/boringssl-2016-02-12/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -13,4 +16,4 @@ get_git_revision https://github.com/google/boringssl.git  894a47df2423f0d2b6be57
 build_lib
 build_libfuzzer
 set -x
-clang++ -I BUILD/include $FUZZ_CXXFLAGS BUILD/fuzz/privkey.cc ./BUILD/ssl/libssl.a ./BUILD/crypto/libcrypto.a libFuzzer.a -o $EXECUTABLE_NAME_BASE
+clang++ -I BUILD/include $FUZZ_CXXFLAGS BUILD/fuzz/privkey.cc ./BUILD/ssl/libssl.a ./BUILD/crypto/libcrypto.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE

--- a/c-ares-CVE-2016-5180/build.sh
+++ b/c-ares-CVE-2016-5180/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/c-ares-CVE-2016-5180/build.sh
+++ b/c-ares-CVE-2016-5180/build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
+
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
@@ -10,4 +14,4 @@ build_lib() {
 get_git_revision https://github.com/c-ares/c-ares.git 51fbb479f7948fca2ace3ff34a15ff27e796afdd SRC
 build_lib
 build_libfuzzer
-clang++ -g $SCRIPT_DIR/target.cc -I  BUILD BUILD/.libs/libcares.a libFuzzer.a  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+clang++ -g $SCRIPT_DIR/target.cc -I  BUILD BUILD/.libs/libcares.a $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE

--- a/common.sh
+++ b/common.sh
@@ -6,8 +6,7 @@
 [ -e $(basename $0) ] && echo "PLEASE USE THIS SCRIPT FROM ANOTHER DIR" && exit 1
 
 # Ensure that argument, if present, is either "libfuzzer" or "afl"
-FUZZER=${1-"libfuzzer"}
-[[ $FUZZER != "libfuzzer" ]] && [[ $FUZZER != "afl" ]] && echo "USAGE: If present, argument \$1 should be either 'afl' or 'libfuzzer'" && exit 1
+[[ ! -z $FUZZER ]] && [[ $FUZZER != "libfuzzer" ]] && [[ $FUZZER != "afl" ]] && echo "USAGE: If present, argument \$1 should be either 'afl' or 'libfuzzer' but it is $FUZZER" && exit 1
 echo "Building with $FUZZER"
 
 SCRIPT_DIR=$(dirname $0)
@@ -23,7 +22,7 @@ CC=${CC:-"clang"}
 CXX=${CXX:-"clang++"}
 CFLAGS=${CFLAGS:-"$FUZZ_CXXFLAGS"}
 CXXFLAGS=${CXXFLAGS:-"$FUZZ_CXXFLAGS"}
-LIB_FUZZING_ENGINE="libFuzzingEngine.a"
+LIB_FUZZING_ENGINE="libFuzzingEngine_${FUZZER}.a"
 
 # Additional build flags (e.g. for libFuzzer) can be passed to build.sh as $UNIQUE_BUILD
 
@@ -59,12 +58,11 @@ build_afl() {
 
 build_libfuzzer() {
   $LIBFUZZER_SRC/build.sh
-  #mv libFuzzer.a $LIB_FUZZING_ENGINE # more consistent style, breaks backwards compatibility
-  LIB_FUZZING_ENGINE="libFuzzer.a"
-  rm *.o
+  mv libFuzzer.a $LIB_FUZZING_ENGINE # more consistent style, breaks backwards compatibility
+  #LIB_FUZZING_ENGINE="libFuzzer.a"
+  #rm *.o
 }
 
 build_fuzzer() {
-  LIB_FUZZING_ENGINE=${LIB_FUZZING_ENGINE}_${FUZZER}
   build_${FUZZER}
 }

--- a/common.sh
+++ b/common.sh
@@ -59,9 +59,7 @@ build_afl() {
 
 build_libfuzzer() {
   $LIBFUZZER_SRC/build.sh
-  mv libFuzzer.a $LIB_FUZZING_ENGINE # more consistent style, breaks backwards compatibility
-  #LIB_FUZZING_ENGINE="libFuzzer.a"
-  #rm *.o
+  mv libFuzzer.a $LIB_FUZZING_ENGINE 
 }
 
 build_fuzzer() {

--- a/common.sh
+++ b/common.sh
@@ -6,8 +6,9 @@
 [ -e $(basename $0) ] && echo "PLEASE USE THIS SCRIPT FROM ANOTHER DIR" && exit 1
 
 # Ensure that argument, if present, is either "libfuzzer" or "afl"
-[[ ! -z $FUZZER ]] && [[ $FUZZER != "libfuzzer" ]] && [[ $FUZZER != "afl" ]] && echo "USAGE: If present, argument \$1 should be either 'afl' or 'libfuzzer' but it is $FUZZER" && exit 1
-echo "Building with $FUZZER"
+FUZZING_ENGINE=${FUZZING_ENGINE:-"libfuzzer"}
+[[ ! -z $FUZZING_ENGINE ]] && [[ $FUZZING_ENGINE != "libfuzzer" ]] && [[ $FUZZING_ENGINE != "afl" ]] && echo "USAGE: If present, argument \$1 should be either 'afl' or 'libfuzzer' but it is $FUZZING_ENGINE" && exit 1
+echo "Building with $FUZZING_ENGINE"
 
 SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)
@@ -22,7 +23,7 @@ CC=${CC:-"clang"}
 CXX=${CXX:-"clang++"}
 CFLAGS=${CFLAGS:-"$FUZZ_CXXFLAGS"}
 CXXFLAGS=${CXXFLAGS:-"$FUZZ_CXXFLAGS"}
-LIB_FUZZING_ENGINE="libFuzzingEngine_${FUZZER}.a"
+LIB_FUZZING_ENGINE="libFuzzingEngine_${FUZZING_ENGINE}.a"
 
 # Additional build flags (e.g. for libFuzzer) can be passed to build.sh as $UNIQUE_BUILD
 
@@ -53,7 +54,7 @@ build_afl() {
   ar r $LIB_FUZZING_ENGINE *.o
   rm *.o
 
-  BINARY_NAME_EXT="_${FUZZER}"
+  BINARY_NAME_EXT="_${FUZZING_ENGINE}"
 }
 
 build_libfuzzer() {
@@ -64,5 +65,5 @@ build_libfuzzer() {
 }
 
 build_fuzzer() {
-  build_${FUZZER}
+  build_${FUZZING_ENGINE}
 }

--- a/common.sh
+++ b/common.sh
@@ -5,9 +5,9 @@
 # Don't allow to call these scripts from their directories.
 [ -e $(basename $0) ] && echo "PLEASE USE THIS SCRIPT FROM ANOTHER DIR" && exit 1
 
-# Ensure that argument, if present, is either "libfuzzer" or "afl"
+# Ensure that fuzzing engine, if defined, is either "libfuzzer" or "afl"
 FUZZING_ENGINE=${FUZZING_ENGINE:-"libfuzzer"}
-[[ ! -z $FUZZING_ENGINE ]] && [[ $FUZZING_ENGINE != "libfuzzer" ]] && [[ $FUZZING_ENGINE != "afl" ]] && echo "USAGE: If present, argument \$1 should be either 'afl' or 'libfuzzer' but it is $FUZZING_ENGINE" && exit 1
+[[ $FUZZING_ENGINE != "libfuzzer" ]] && [[ $FUZZING_ENGINE != "afl" ]] && echo "USAGE: If defined, $FUZZING_ENGINE should be either 'afl' or 'libfuzzer' but it is $FUZZING_ENGINE" && exit 1
 echo "Building with $FUZZING_ENGINE"
 
 SCRIPT_DIR=$(dirname $0)

--- a/common.sh
+++ b/common.sh
@@ -51,14 +51,14 @@ build_afl() {
   $CC -c -w $AFL_SRC/llvm_mode/afl-llvm-rt.o.c
   $CXX -g -fsanitize-coverage=trace-pc-guard $TARGET_FILE $TARGET_INCLUDE -c
 
-  UNIQUE_BUILD="$UNIQUE_BUILD $AFL_DRIVER afl-llvm-rt.o.o ${TARGET_NAME}.o"
+  UNIQUE_BUILD="$AFL_DRIVER afl-llvm-rt.o.o ${TARGET_NAME}.o $UNIQUE_BUILD"
   BINARY_NAME_EXT="_${FUZZER}"
 }
 
 build_libfuzzer() {
   $LIBFUZZER_SRC/build.sh
 
-  UNIQUE_BUILD="$UNIQUE_BUILD libFuzzer.a ${TARGET_FILE}"
+  UNIQUE_BUILD="${TARGET_FILE} libFuzzer.a $UNIQUE_BUILD"
 }
 
 build_fuzzer() {

--- a/common.sh
+++ b/common.sh
@@ -1,15 +1,50 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
 # Don't allow to call these scripts from their directories.
 [ -e $(basename $0) ] && echo "PLEASE USE THIS SCRIPT FROM ANOTHER DIR" && exit 1
+
+# Ensure that argument, if present, is either "libfuzzer" or "afl"
+FUZZER=${1-"libfuzzer"}
+[[ $FUZZER != "libfuzzer" ]] && [[ $FUZZER != "afl" ]] && echo "USAGE: Enter 'afl' as argument \$1 to build using AFL" && exit 1
+
 SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)
 LIBFUZZER_SRC=$(dirname $(dirname $SCRIPT_DIR))/Fuzzer
+AFL_DRIVER=$LIBFUZZER_SRC/afl/afl_driver.cpp
+AFL_HOME=$(dirname $(dirname $SCRIPT_DIR))/AFL
 FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div"
 CORPUS=CORPUS-$EXECUTABLE_NAME_BASE
 JOBS=8
+
+target_files
+echo "Building with $FUZZER"
+
+CC="clang"
+CXX="clang++"
+CFLAGS=""
+CXXFLAGS=""
+
+# Additional build flags e.g. for libFuzzer can be pre-defined with FUZZER_BUILD_FLAGS
+FUZZER_BUILD_FLAGS="$FUZZER_BUILD_FLAGS $TARGET_LIBRARY"
+
+if [[ $FUZZER == "afl" ]]
+then
+  FUZZER_BUILD_FLAGS="$FUZZER_BUILD_FLAGS $AFL_DRIVER afl-llvm-rt.o.o"
+  FINAL_TARGET="${TARGET_NAME}.o ${TARGET_INCLUDE}"
+  BINARY_NAME_EXT="_${FUZZER}"
+fi
+
+if [[ $FUZZER == "libfuzzer" ]]
+then
+  CXXFLAGS=$FUZZ_CXXFLAGS
+  CFLAGS=$CXXFLAGS
+  CC="$CC $CXXFLAGS"
+  CXX="$CXX $CXXFLAGS"
+  FUZZER_BUILD_FLAGS="$FUZZER_BUILD_FLAGS libFuzzer.a"
+  FINAL_TARGET=$TARGET_C
+fi
 
 get_git_revision() {
   GIT_REPO="$1"
@@ -32,6 +67,15 @@ get_svn_revision() {
   [ ! -e $TO_DIR ] && svn co -r$SVN_REVISION $SVN_REPO $TO_DIR
 }
 
+build_afl() {
+  $CC -c -w $AFL_HOME/llvm_mode/afl-llvm-rt.o.c
+  $CXX -g -fsanitize-coverage=trace-pc-guard $TARGET_C -c
+}
+
 build_libfuzzer() {
   $LIBFUZZER_SRC/build.sh
+}
+
+build_fuzzer() {
+  build_${FUZZER}
 }

--- a/guetzli-2017-3-30/build.sh
+++ b/guetzli-2017-3-30/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/guetzli-2017-3-30/build.sh
+++ b/guetzli-2017-3-30/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -13,4 +16,4 @@ get_git_tag https://github.com/google/guetzli.git 9afd0bbb7db0bd3a50226845f0f6c3
 build_lib
 build_libfuzzer
 set -x
-clang++ -g -std=c++11 BUILD/fuzz_target.cc -I BUILD/ BUILD/bin/Release/libguetzli_static.a libFuzzer.a  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+clang++ -g -std=c++11 BUILD/fuzz_target.cc -I BUILD/ BUILD/bin/Release/libguetzli_static.a $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE

--- a/harfbuzz-1.3.2/build.sh
+++ b/harfbuzz-1.3.2/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 get_git_revision https://github.com/behdad/harfbuzz.git  f73a87d9a8c76a181794b74b527ea268048f78e3 SRC
@@ -15,4 +18,4 @@ build_lib() {
 build_lib
 build_libfuzzer
 set -x
-clang++  -std=c++11 -I BUILD/src/ BUILD/test/fuzzing/hb-fuzzer.cc BUILD/src/.libs/libharfbuzz-fuzzing.a libFuzzer.a  $FUZZ_CXXFLAGS -lglib-2.0 -o $EXECUTABLE_NAME_BASE
+clang++  -std=c++11 -I BUILD/src/ BUILD/test/fuzzing/hb-fuzzer.cc BUILD/src/.libs/libharfbuzz-fuzzing.a $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -lglib-2.0 -o $EXECUTABLE_NAME_BASE

--- a/harfbuzz-1.3.2/build.sh
+++ b/harfbuzz-1.3.2/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 get_git_revision https://github.com/behdad/harfbuzz.git  f73a87d9a8c76a181794b74b527ea268048f78e3 SRC

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -4,11 +4,6 @@
 
 . $(dirname $0)/../common.sh $1
 
-TARGET_NAME="cms_transform_fuzzer"
-TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}.c"
-TARGET_INCLUDE="-I BUILD/include/"
-UNIQUE_BUILD="$UNIQUE_BUILD $TARGET_INCLUDE BUILD/src/.libs/liblcms2.a"
-
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
@@ -19,4 +14,4 @@ get_git_revision https://github.com/mm2/Little-CMS.git f9d75ccef0b54c9f4167d9508
 build_lib
 build_fuzzer
 set -x
-build_binary
+$CXX $CXXFLAGS ${SCRIPT_DIR}/cms_transform_fuzzer.c -I BUILD/include/ BUILD/src/.libs/liblcms2.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -2,15 +2,12 @@
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
-target_files(){
-  TARGET_NAME=cms_transform_fuzzer
-  TARGET_INCLUDE="-I BUILD/include/"
-  TARGET_LIBRARY="BUILD/src/.libs/liblcms2.a"
-  TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}"
-  TARGET_C="${TARGET_FILE}.c ${TARGET_INCLUDE}"
-}
-
 . $(dirname $0)/../common.sh $1
+
+TARGET_NAME="cms_transform_fuzzer"
+TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}.c"
+TARGET_INCLUDE="-I BUILD/include/"
+UNIQUE_BUILD="$UNIQUE_BUILD $TARGET_INCLUDE BUILD/src/.libs/liblcms2.a"
 
 build_lib() {
   rm -rf BUILD
@@ -21,7 +18,4 @@ build_lib() {
 get_git_revision https://github.com/mm2/Little-CMS.git f9d75ccef0b54c9f4167d95088d4727985133c52 SRC
 build_lib
 build_fuzzer
-
-set -x
-
-$CXX $FINAL_TARGET $FUZZER_BUILD_FLAGS -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}
+build_binary

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -18,4 +18,5 @@ build_lib() {
 get_git_revision https://github.com/mm2/Little-CMS.git f9d75ccef0b54c9f4167d95088d4727985133c52 SRC
 build_lib
 build_fuzzer
+set -x
 build_binary

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -1,16 +1,27 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-. $(dirname $0)/../common.sh
+
+target_files(){
+  TARGET_NAME=cms_transform_fuzzer
+  TARGET_INCLUDE="-I BUILD/include/"
+  TARGET_LIBRARY="BUILD/src/.libs/liblcms2.a"
+  TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}"
+  TARGET_C="${TARGET_FILE}.c ${TARGET_INCLUDE}"
+}
+
+. $(dirname $0)/../common.sh $1
 
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh && CXX="clang++ $FUZZ_CXXFLAGS" CC="clang $FUZZ_CXXFLAGS" CCLD="clang++ $FUZZ_CXXFLAGS"  ./configure && make -j $JOBS)
+  (cd BUILD && ./autogen.sh && ./configure && make -j $JOBS)
 }
 
 get_git_revision https://github.com/mm2/Little-CMS.git f9d75ccef0b54c9f4167d95088d4727985133c52 SRC
 build_lib
-build_libfuzzer
+build_fuzzer
+
 set -x
-clang++ $SCRIPT_DIR/cms_transform_fuzzer.c -I BUILD/include/ $FUZZ_CXXFLAGS BUILD/src/.libs/liblcms2.a libFuzzer.a -o $EXECUTABLE_NAME_BASE
+
+$CXX $FINAL_TARGET $FUZZER_BUILD_FLAGS -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -2,7 +2,9 @@
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
-. $(dirname $0)/../common.sh $1
+FUZZER=${1-"libfuzzer"}
+
+. $(dirname $0)/../common.sh
 
 build_lib() {
   rm -rf BUILD

--- a/libarchive-2017-01-04/build.sh
+++ b/libarchive-2017-01-04/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/libarchive-2017-01-04/build.sh
+++ b/libarchive-2017-01-04/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -13,4 +16,4 @@ get_git_revision https://github.com/libarchive/libarchive.git 51d7afd3644fdad725
 build_lib
 build_libfuzzer
 set -x
-clang++ -std=c++11  -I BUILD/libarchive $SCRIPT_DIR/libarchive_fuzzer.cc  BUILD/.libs/libarchive.a libFuzzer.a -lz -lxml2 -lcrypto -lssl $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+clang++ -std=c++11  -I BUILD/libarchive $SCRIPT_DIR/libarchive_fuzzer.cc  BUILD/.libs/libarchive.a $LIB_FUZZING_ENGINE -lz -lxml2 -lcrypto -lssl $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE

--- a/libjpeg-turbo-07-2017/build.sh
+++ b/libjpeg-turbo-07-2017/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -13,4 +16,4 @@ get_git_revision https://github.com/libjpeg-turbo/libjpeg-turbo.git b0971e47d76f
 build_lib
 build_libfuzzer
 set -x
-clang++ -std=c++11 $SCRIPT_DIR/libjpeg_turbo_fuzzer.cc  $FUZZ_CXXFLAGS -I BUILD BUILD/.libs/libturbojpeg.a libFuzzer.a -o $EXECUTABLE_NAME_BASE
+clang++ -std=c++11 $SCRIPT_DIR/libjpeg_turbo_fuzzer.cc  $FUZZ_CXXFLAGS -I BUILD BUILD/.libs/libturbojpeg.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE

--- a/libjpeg-turbo-07-2017/build.sh
+++ b/libjpeg-turbo-07-2017/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/libpng-1.2.56/build.sh
+++ b/libpng-1.2.56/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 [ ! -e libpng-1.2.56.tar.gz ] && wget ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng12/libpng-1.2.56.tar.gz

--- a/libpng-1.2.56/build.sh
+++ b/libpng-1.2.56/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 [ ! -e libpng-1.2.56.tar.gz ] && wget ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng12/libpng-1.2.56.tar.gz
@@ -15,4 +18,4 @@ build_lib() {
 build_lib
 build_libfuzzer
 set -x
-clang++ -g -std=c++11 $FUZZ_CXXFLAGS $SCRIPT_DIR/target.cc BUILD/.libs/libpng12.a libFuzzer.a  -I BUILD/ -I BUILD -lz -o $EXECUTABLE_NAME_BASE-lf
+clang++ -g -std=c++11 $FUZZ_CXXFLAGS $SCRIPT_DIR/target.cc BUILD/.libs/libpng12.a $LIB_FUZZING_ENGINE -I BUILD/ -I BUILD -lz -o $EXECUTABLE_NAME_BASE-lf

--- a/libxml2-v2.9.2/build.sh
+++ b/libxml2-v2.9.2/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/libxml2-v2.9.2/build.sh
+++ b/libxml2-v2.9.2/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -14,4 +17,4 @@ get_git_revision https://github.com/mcarpenter/afl be3e88d639da5350603f6c0fee069
 build_lib
 build_libfuzzer
 set -x
-clang++ -std=c++11  $SCRIPT_DIR/target.cc  $FUZZ_CXXFLAGS  -I BUILD/include BUILD/.libs/libxml2.a libFuzzer.a  -lz -o $EXECUTABLE_NAME_BASE
+clang++ -std=c++11  $SCRIPT_DIR/target.cc  $FUZZ_CXXFLAGS  -I BUILD/include BUILD/.libs/libxml2.a $LIB_FUZZING_ENGINE  -lz -o $EXECUTABLE_NAME_BASE

--- a/llvm-libcxxabi-2017-01-27/build.sh
+++ b/llvm-libcxxabi-2017-01-27/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 get_svn_revision http://llvm.org/svn/llvm-project/libcxxabi/trunk 293329 SRC

--- a/llvm-libcxxabi-2017-01-27/build.sh
+++ b/llvm-libcxxabi-2017-01-27/build.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 get_svn_revision http://llvm.org/svn/llvm-project/libcxxabi/trunk 293329 SRC
 build_libfuzzer
 
 clang++ -std=c++11 SRC/fuzz/cxa_demangle_fuzzer.cpp SRC/src/cxa_demangle.cpp -I SRC/include \
-  $FUZZ_CXXFLAGS libFuzzer.a -o $EXECUTABLE_NAME_BASE
+  $FUZZ_CXXFLAGS $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE

--- a/openssl-1.0.1f/build.sh
+++ b/openssl-1.0.1f/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/openssl-1.0.1f/build.sh
+++ b/openssl-1.0.1f/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -12,4 +15,4 @@ build_lib() {
 get_git_tag https://github.com/openssl/openssl.git OpenSSL_1_0_1f SRC
 build_lib
 build_libfuzzer
-clang++ -g $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a libFuzzer.a -o $EXECUTABLE_NAME_BASE -I BUILD/include
+clang++ -g $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE -I BUILD/include

--- a/openssl-1.0.2d/build.sh
+++ b/openssl-1.0.2d/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -13,4 +16,4 @@ get_git_tag https://github.com/openssl/openssl.git OpenSSL_1_0_2d SRC
 build_lib
 build_libfuzzer
 set -x
-clang++ -g $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a libFuzzer.a -lgcrypt -o $EXECUTABLE_NAME_BASE -I BUILD/include
+clang++ -g $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -lgcrypt -o $EXECUTABLE_NAME_BASE -I BUILD/include

--- a/openssl-1.0.2d/build.sh
+++ b/openssl-1.0.2d/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/openssl-1.1.0c/build.sh
+++ b/openssl-1.1.0c/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -14,4 +17,4 @@ build_lib
 build_libfuzzer
 set -x
 clang $FUZZ_CXXFLAGS -DFuzzerTestOneInput=LLVMFuzzerTestOneInput -c -g BUILD/fuzz/bignum.c -I BUILD/include
-clang++ bignum.o $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a libFuzzer.a -lgcrypt -o $EXECUTABLE_NAME_BASE
+clang++ bignum.o $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -lgcrypt -o $EXECUTABLE_NAME_BASE

--- a/openssl-1.1.0c/build.sh
+++ b/openssl-1.1.0c/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/pcre2-10.00/build.sh
+++ b/pcre2-10.00/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/pcre2-10.00/build.sh
+++ b/pcre2-10.00/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_lib() {
@@ -17,4 +20,4 @@ get_svn_revision svn://vcs.exim.org/pcre2/code/trunk 183 SRC
 build_lib
 build_libfuzzer
 set -x
-clang++ $SCRIPT_DIR/target.cc -I BUILD/src -Wl,--whole-archive BUILD/.libs/*.a -Wl,-no-whole-archive libFuzzer.a  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+clang++ $SCRIPT_DIR/target.cc -I BUILD/src -Wl,--whole-archive BUILD/.libs/*.a -Wl,-no-whole-archive $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -1,15 +1,27 @@
 #!/bin/bash
-# Copyright 2016 Google Inc. All Rights Reserved.
+# Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-. $(dirname $0)/../common.sh
+
+target_files(){
+  TARGET_NAME=target
+  TARGET_INCLUDE="-I BUILD/"
+  TARGET_LIBRARY="BUILD/obj/libre2.a"
+  TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}"
+  TARGET_C="${TARGET_FILE}.cc ${TARGET_INCLUDE}"
+}
+
+. $(dirname $0)/../common.sh $1
 
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && make clean && CXX=clang++ CXXFLAGS="$FUZZ_CXXFLAGS"  make -j)
+  (cd BUILD && make clean &&  make -j)
 }
 
 get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a77b6ac335de SRC
 build_lib
-build_libfuzzer
-clang++ -g $SCRIPT_DIR/target.cc -I  BUILD BUILD/obj/libre2.a libFuzzer.a  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+build_fuzzer
+
+set -x
+
+$CXX $FINAL_TARGET $FUZZER_BUILD_FLAGS -lpthread -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -4,11 +4,6 @@
 
 . $(dirname $0)/../common.sh $1
 
-TARGET_NAME="target"
-TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}.cc"
-TARGET_INCLUDE="-I BUILD/"
-UNIQUE_BUILD="$UNIQUE_BUILD $TARGET_INCLUDE BUILD/obj/libre2.a -lpthread"
-
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
@@ -19,4 +14,4 @@ get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a
 build_lib
 build_fuzzer
 set -x
-build_binary
+$CXX $CXXFLAGS ${SCRIPT_DIR}/target.cc  -I BUILD/ BUILD/obj/libre2.a -lpthread $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_lib() {

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -2,15 +2,12 @@
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
-target_files(){
-  TARGET_NAME=target
-  TARGET_INCLUDE="-I BUILD/"
-  TARGET_LIBRARY="BUILD/obj/libre2.a"
-  TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}"
-  TARGET_C="${TARGET_FILE}.cc ${TARGET_INCLUDE}"
-}
-
 . $(dirname $0)/../common.sh $1
+
+TARGET_NAME="target"
+TARGET_FILE="${SCRIPT_DIR}/${TARGET_NAME}.cc"
+TARGET_INCLUDE="-I BUILD/"
+UNIQUE_BUILD="$UNIQUE_BUILD $TARGET_INCLUDE BUILD/obj/libre2.a -lpthread"
 
 build_lib() {
   rm -rf BUILD
@@ -21,7 +18,4 @@ build_lib() {
 get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a77b6ac335de SRC
 build_lib
 build_fuzzer
-
-set -x
-
-$CXX $FINAL_TARGET $FUZZER_BUILD_FLAGS -lpthread -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}
+build_binary

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -2,7 +2,9 @@
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
-. $(dirname $0)/../common.sh $1
+FUZZER=${1-"libfuzzer"}
+
+. $(dirname $0)/../common.sh
 
 build_lib() {
   rm -rf BUILD

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -18,4 +18,5 @@ build_lib() {
 get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a77b6ac335de SRC
 build_lib
 build_fuzzer
+set -x
 build_binary

--- a/sqlite-2016-11-14/build.sh
+++ b/sqlite-2016-11-14/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 build_libfuzzer

--- a/sqlite-2016-11-14/build.sh
+++ b/sqlite-2016-11-14/build.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 build_libfuzzer
 clang -c $FUZZ_CXXFLAGS $SCRIPT_DIR/sqlite3.c
 clang -c $FUZZ_CXXFLAGS $SCRIPT_DIR/ossfuzz.c
-clang++ sqlite3.o ossfuzz.o libFuzzer.a $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+clang++ sqlite3.o ossfuzz.o $LIB_FUZZING_ENGINE $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE

--- a/woff2-2016-05-06/build.sh
+++ b/woff2-2016-05-06/build.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
+
+FUZZER=${1-"libfuzzer"}
+
 . $(dirname $0)/../common.sh
 
 get_git_revision https://github.com/google/woff2.git  9476664fd6931ea6ec532c94b816d8fbbe3aed90 SRC
@@ -18,4 +21,4 @@ done
 wait
 
 set -x
-clang++ *.o libFuzzer.a $SCRIPT_DIR/target.cc -I SRC/src $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+clang++ *.o $LIB_FUZZING_ENGINE $SCRIPT_DIR/target.cc -I SRC/src $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE

--- a/woff2-2016-05-06/build.sh
+++ b/woff2-2016-05-06/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # Copyright 2016 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
-
-FUZZER=${1-"libfuzzer"}
-
 . $(dirname $0)/../common.sh
 
 get_git_revision https://github.com/google/woff2.git  9476664fd6931ea6ec532c94b816d8fbbe3aed90 SRC


### PR DESCRIPTION
To build with afl, call:

`./build.sh afl`

Otherwise, both of these are equivalent:

```
./build.sh libfuzzer
./build.sh
```

We now name binaries "(name)_afl" in AFL mode, but maintain the status quo for libfuzzer; this way backward compatibility is maintained.