### PR TITLE
AFL building for every benchmark

### DIFF
--- a/boringssl-2016-02-12/build.sh
+++ b/boringssl-2016-02-12/build.sh
@@ -6,7 +6,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS="$CFLAGS -Wno-error=main" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=main" && make -j)
+  (cd BUILD && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS="$CFLAGS" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=main" && make -j)
 }
 
 get_git_revision https://github.com/google/boringssl.git  894a47df2423f0d2b6be57e6d90f2bea88213382 SRC

--- a/boringssl-2016-02-12/build.sh
+++ b/boringssl-2016-02-12/build.sh
@@ -6,11 +6,11 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && cmake  -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER=clang -DCMAKE_C_FLAGS="$FUZZ_CXXFLAGS" -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=main" && make -j)
+  (cd BUILD && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS="$CFLAGS -Wno-error=main" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=main" && make -j)
 }
 
 get_git_revision https://github.com/google/boringssl.git  894a47df2423f0d2b6be57e6d90f2bea88213382 SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -I BUILD/include $FUZZ_CXXFLAGS BUILD/fuzz/privkey.cc ./BUILD/ssl/libssl.a ./BUILD/crypto/libcrypto.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -I BUILD/include BUILD/fuzz/privkey.cc ./BUILD/ssl/libssl.a ./BUILD/crypto/libcrypto.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/c-ares-CVE-2016-5180/build.sh
+++ b/c-ares-CVE-2016-5180/build.sh
@@ -6,9 +6,9 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./buildconf && ./configure CC="clang $FUZZ_CXXFLAGS" &&  make CFLAGS= -j )
+  (cd BUILD && ./buildconf && ./configure &&  make CFLAGS= -j )
 }
 get_git_revision https://github.com/c-ares/c-ares.git 51fbb479f7948fca2ace3ff34a15ff27e796afdd SRC
 build_lib
-build_libfuzzer
-clang++ -g $SCRIPT_DIR/target.cc -I  BUILD BUILD/.libs/libcares.a $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+build_fuzzer
+$CXX $CXXFLAGS $SCRIPT_DIR/target.cc -I  BUILD BUILD/.libs/libcares.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/guetzli-2017-3-30/build.sh
+++ b/guetzli-2017-3-30/build.sh
@@ -11,6 +11,6 @@ build_lib() {
 
 get_git_tag https://github.com/google/guetzli.git 9afd0bbb7db0bd3a50226845f0f6c36f14933b6b SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -g -std=c++11 BUILD/fuzz_target.cc -I BUILD/ BUILD/bin/Release/libguetzli_static.a $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 BUILD/fuzz_target.cc -I BUILD/ BUILD/bin/Release/libguetzli_static.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/harfbuzz-1.3.2/build.sh
+++ b/harfbuzz-1.3.2/build.sh
@@ -8,11 +8,11 @@ get_git_revision https://github.com/behdad/harfbuzz.git  f73a87d9a8c76a181794b74
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh && CXX="clang++ $FUZZ_CXXFLAGS"  CC="clang $FUZZ_CXXFLAGS" CCLD="clang++ $FUZZ_CXXFLAGS" ./configure --enable-static --disable-shared &&
+  (cd BUILD && ./autogen.sh && CCLD="$CXX $CXXFLAGS" ./configure --enable-static --disable-shared &&
     make -j $JOBS -C src fuzzing)
 }
 
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++  -std=c++11 -I BUILD/src/ BUILD/test/fuzzing/hb-fuzzer.cc BUILD/src/.libs/libharfbuzz-fuzzing.a $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -lglib-2.0 -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 -I BUILD/src/ BUILD/test/fuzzing/hb-fuzzer.cc BUILD/src/.libs/libharfbuzz-fuzzing.a $LIB_FUZZING_ENGINE -lglib-2.0 -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/libarchive-2017-01-04/build.sh
+++ b/libarchive-2017-01-04/build.sh
@@ -6,11 +6,11 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD/build && ./autogen.sh && cd .. && CXX="clang++ $FUZZ_CXXFLAGS" CC="clang $FUZZ_CXXFLAGS" CCLD="clang++ $FUZZ_CXXFLAGS"  ./configure && make -j $JOBS)
+  (cd BUILD/build && ./autogen.sh && cd .. && ./configure && make -j $JOBS)
 }
 
 get_git_revision https://github.com/libarchive/libarchive.git 51d7afd3644fdad725dd8faa7606b864fd125f88 SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -std=c++11  -I BUILD/libarchive $SCRIPT_DIR/libarchive_fuzzer.cc  BUILD/.libs/libarchive.a $LIB_FUZZING_ENGINE -lz -lxml2 -lcrypto -lssl $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 $SCRIPT_DIR/libarchive_fuzzer.cc -I BUILD/libarchive BUILD/.libs/libarchive.a $LIB_FUZZING_ENGINE -lz -lxml2 -lcrypto -lssl -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/libjpeg-turbo-07-2017/build.sh
+++ b/libjpeg-turbo-07-2017/build.sh
@@ -6,11 +6,11 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && autoreconf -fiv && CXX="clang++ $FUZZ_CXXFLAGS" CC="clang $FUZZ_CXXFLAGS" ./configure && make -j $JOBS)
+  (cd BUILD && autoreconf -fiv && ./configure && make -j $JOBS)
 }
 
 get_git_revision https://github.com/libjpeg-turbo/libjpeg-turbo.git b0971e47d76fdb81270e93bbf11ff5558073350d SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -std=c++11 $SCRIPT_DIR/libjpeg_turbo_fuzzer.cc  $FUZZ_CXXFLAGS -I BUILD BUILD/.libs/libturbojpeg.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 $SCRIPT_DIR/libjpeg_turbo_fuzzer.cc -I BUILD BUILD/.libs/libturbojpeg.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/libpng-1.2.56/build.sh
+++ b/libpng-1.2.56/build.sh
@@ -9,10 +9,10 @@
 build_lib() {
   rm -rf BUILD
   cp -rf libpng-1.2.56 BUILD
-  (cd BUILD && ./configure CC="clang" CFLAGS="$FUZZ_CXXFLAGS" &&  make -j)
+  (cd BUILD && ./configure &&  make -j)
 }
 
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -g -std=c++11 $FUZZ_CXXFLAGS $SCRIPT_DIR/target.cc BUILD/.libs/libpng12.a $LIB_FUZZING_ENGINE -I BUILD/ -I BUILD -lz -o $EXECUTABLE_NAME_BASE-lf
+$CXX $CXXFLAGS -std=c++11 $SCRIPT_DIR/target.cc BUILD/.libs/libpng12.a $LIB_FUZZING_ENGINE -I BUILD/ -I BUILD -lz -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}-lf

--- a/libxml2-v2.9.2/build.sh
+++ b/libxml2-v2.9.2/build.sh
@@ -6,12 +6,12 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh && CXX="clang++ $FUZZ_CXXFLAGS" CC="clang $FUZZ_CXXFLAGS" CCLD="clang++ $FUZZ_CXXFLAGS"  ./configure && make -j $JOBS)
+  (cd BUILD && ./autogen.sh && CCLD="$CXX $CXXFLAGS" ./configure && make -j $JOBS)
 }
 
 get_git_tag git://git.gnome.org/libxml2  v2.9.2 SRC
 get_git_revision https://github.com/mcarpenter/afl be3e88d639da5350603f6c0fee06970128504342 afl
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -std=c++11  $SCRIPT_DIR/target.cc  $FUZZ_CXXFLAGS  -I BUILD/include BUILD/.libs/libxml2.a $LIB_FUZZING_ENGINE  -lz -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11  $SCRIPT_DIR/target.cc -I BUILD/include BUILD/.libs/libxml2.a $LIB_FUZZING_ENGINE -lz -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/llvm-libcxxabi-2017-01-27/build.sh
+++ b/llvm-libcxxabi-2017-01-27/build.sh
@@ -4,7 +4,7 @@
 . $(dirname $0)/../common.sh
 
 get_svn_revision http://llvm.org/svn/llvm-project/libcxxabi/trunk 293329 SRC
-build_libfuzzer
+build_fuzzer
 
-clang++ -std=c++11 SRC/fuzz/cxa_demangle_fuzzer.cpp SRC/src/cxa_demangle.cpp -I SRC/include \
-  $FUZZ_CXXFLAGS $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 SRC/fuzz/cxa_demangle_fuzzer.cpp SRC/src/cxa_demangle.cpp -I SRC/include \
+   $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/openssl-1.0.1f/build.sh
+++ b/openssl-1.0.1f/build.sh
@@ -12,4 +12,4 @@ build_lib() {
 get_git_tag https://github.com/openssl/openssl.git OpenSSL_1_0_1f SRC
 build_lib
 build_fuzzer
-$CXX $CXXFLAGS $SCRIPT_DIR/target.cc -I BUILD/include -DCERT_PATH=\"$SCRIPT_DIR/\"  BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}
+$CXX $CXXFLAGS $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -I BUILD/include -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/openssl-1.0.1f/build.sh
+++ b/openssl-1.0.1f/build.sh
@@ -6,10 +6,10 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./config && make clean && make CC="clang $FUZZ_CXXFLAGS"  -j $JOBS)
+  (cd BUILD && ./config && make clean && make -j $JOBS)
 }
 
 get_git_tag https://github.com/openssl/openssl.git OpenSSL_1_0_1f SRC
 build_lib
-build_libfuzzer
-clang++ -g $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE -I BUILD/include
+build_fuzzer
+$CXX $CXXFLAGS $SCRIPT_DIR/target.cc -I BUILD/include -DCERT_PATH=\"$SCRIPT_DIR/\"  BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/openssl-1.0.2d/build.sh
+++ b/openssl-1.0.2d/build.sh
@@ -6,11 +6,11 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./config && make clean && make CC="clang $FUZZ_CXXFLAGS"  -j $JOBS)
+  (cd BUILD && ./config && make clean && make -j $JOBS)
 }
 
 get_git_tag https://github.com/openssl/openssl.git OpenSSL_1_0_2d SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ -g $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -lgcrypt -o $EXECUTABLE_NAME_BASE -I BUILD/include
+$CXX $CXXFLAGS $SCRIPT_DIR/target.cc -DCERT_PATH=\"$SCRIPT_DIR/\"  BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -lgcrypt -I BUILD/include -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/openssl-1.1.0c/build.sh
+++ b/openssl-1.1.0c/build.sh
@@ -6,12 +6,12 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./config && make clean && make CC="clang $FUZZ_CXXFLAGS"  -j $JOBS)
+  (cd BUILD && ./config && make clean && make -j $JOBS)
 }
 
 get_git_tag https://github.com/openssl/openssl.git OpenSSL_1_1_0c SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang $FUZZ_CXXFLAGS -DFuzzerTestOneInput=LLVMFuzzerTestOneInput -c -g BUILD/fuzz/bignum.c -I BUILD/include
-clang++ bignum.o $FUZZ_CXXFLAGS BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -lgcrypt -o $EXECUTABLE_NAME_BASE
+$CC $CFLAGS -DFuzzerTestOneInput=LLVMFuzzerTestOneInput -c -g BUILD/fuzz/bignum.c -I BUILD/include
+$CXX $CXXFLAGS bignum.o BUILD/libssl.a BUILD/libcrypto.a $LIB_FUZZING_ENGINE -lgcrypt -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/pcre2-10.00/build.sh
+++ b/pcre2-10.00/build.sh
@@ -8,13 +8,13 @@ build_lib() {
   cp -rf SRC BUILD
   (cd BUILD &&
     ./autogen.sh &&
-     CXX="clang++ $FUZZ_CXXFLAGS" CC="clang $FUZZ_CXXFLAGS" CCLD="clang++ $FUZZ_CXXFLAGS" ./configure --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-recursion=1000 &&
+     CCLD="$CXX $CXXFLAGS" ./configure --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-recursion=1000 &&
      make -j
   )
 }
 
 get_svn_revision svn://vcs.exim.org/pcre2/code/trunk 183 SRC
 build_lib
-build_libfuzzer
+build_fuzzer
 set -x
-clang++ $SCRIPT_DIR/target.cc -I BUILD/src -Wl,--whole-archive BUILD/.libs/*.a -Wl,-no-whole-archive $LIB_FUZZING_ENGINE  $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS $SCRIPT_DIR/target.cc -I BUILD/src -Wl,--whole-archive BUILD/.libs/*.a -Wl,-no-whole-archive $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/sqlite-2016-11-14/build.sh
+++ b/sqlite-2016-11-14/build.sh
@@ -4,7 +4,7 @@
 . $(dirname $0)/../common.sh
 
 set -x
-build_libfuzzer
-clang -c $FUZZ_CXXFLAGS $SCRIPT_DIR/sqlite3.c
-clang -c $FUZZ_CXXFLAGS $SCRIPT_DIR/ossfuzz.c
-clang++ sqlite3.o ossfuzz.o $LIB_FUZZING_ENGINE $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+build_fuzzer
+$CC $CFLAGS -c $SCRIPT_DIR/sqlite3.c
+$CC $CFLAGS -c $SCRIPT_DIR/ossfuzz.c
+$CXX $CXXFLAGS sqlite3.o ossfuzz.o $LIB_FUZZING_ENGINE -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}

--- a/woff2-2016-05-06/build.sh
+++ b/woff2-2016-05-06/build.sh
@@ -6,16 +6,16 @@
 get_git_revision https://github.com/google/woff2.git  9476664fd6931ea6ec532c94b816d8fbbe3aed90 SRC
 get_git_revision https://github.com/google/brotli.git 3a9032ba8733532a6cd6727970bade7f7c0e2f52 BROTLI
 get_git_revision https://github.com/FontFaceKit/roboto.git 0e41bf923e2599d651084eece345701e55a8bfde SEED_CORPUS
-build_libfuzzer
+build_fuzzer
 
 rm -f *.o
 for f in font.cc normalize.cc transform.cc woff2_common.cc woff2_dec.cc woff2_enc.cc glyph.cc table_tags.cc variable_length.cc woff2_out.cc; do
-  clang++ $FUZZ_CXXFLAGS -std=c++11  -I BROTLI/dec -I BROTLI/enc -c SRC/src/$f &
+  $CXX $CXXFLAGS -std=c++11  -I BROTLI/dec -I BROTLI/enc -c SRC/src/$f &
 done
 for f in BROTLI/dec/*.c BROTLI/enc/*.cc; do
-  clang++ $FUZZ_CXXFLAGS -c $f &
+  $CXX $CXXFLAGS -c $f &
 done
 wait
 
 set -x
-clang++ *.o $LIB_FUZZING_ENGINE $SCRIPT_DIR/target.cc -I SRC/src $FUZZ_CXXFLAGS -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS *.o $LIB_FUZZING_ENGINE $SCRIPT_DIR/target.cc -I SRC/src -o ${EXECUTABLE_NAME_BASE}${BINARY_NAME_EXT}


### PR DESCRIPTION
These are the same changes for each build.sh. In summary, they are:

- Use CC, CFLAGS, CXX, CXXFLAGS, LIB_FUZZING_ENGINE
- Use build_fuzzer instead of build_libfuzzer
- Name binaries with "_afl" if necessary
