### PR TITLE
Dispatcher skeleton

### DIFF
--- a/engine_comparison/Dockerfile
+++ b/engine_comparison/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+
+FROM ubuntu:16.04
+RUN apt-get update && apt-get upgrade -y && apt-get autoremove -y && apt-get install -y git sudo
+# All dependencies for benchmarks
+
+RUN ~/run.sh
+

--- a/engine_comparison/begin_experiment.sh
+++ b/engine_comparison/begin_experiment.sh
@@ -25,7 +25,7 @@ else
 fi
 
 # Create one gcloud instance for the dispatcher
-gcloud compute instances create $INSTANCE_NAME --image-family=$DISPATCHER_IMAGE_FAMILY --image-project=$PROJECT_NAME
+gcloud compute instances create $INSTANCE_NAME --image-family=$DISPATCHER_IMAGE_FAMILY --image-project=ubuntu-os-cloud
 
 # Send configs for the fuzzing engine
 export FENGINE_CONFIGS_DIR=${FENGINE_CONFIGS_DIR:-"~/fuzzing_engine_configs"}
@@ -44,7 +44,7 @@ rm -rf ${SCRIPT_DIR}/tmp-configs
 gcloud compute scp --recurse $SCRIPT_DIR $INSTANCE_NAME:~/
 
 # Run dispatcher with Docker
-DISPATCHER_COMMAND="docker build -f ~/${SCRIPT_DIR}/engine_comparison/dispatcher/ ."
+DISPATCHER_COMMAND="docker build -f ~/${SCRIPT_DIR}/engine_comparison/ ."
 gcloud compute ssh $INSTANCE_NAME --command=$DISPATCHER_COMMAND
 
 

--- a/engine_comparison/dispatcher.sh
+++ b/engine_comparison/dispatcher.sh
@@ -28,7 +28,7 @@ build_benchmark_using() {
   ~/$FTS/$1/build.sh $FENGINE_NAME $FUZZING_ENGINE
 
   # copy binaries
-
+  # copy Dockerfile
   # TODO Add other items eg ./afl-fuzz, seeds
 }
 
@@ -45,7 +45,7 @@ for FENGINE_CONFIG in $(find ~/$FENGINE_CONFIGS_DIR); do
 
     gcloud compute instances create $INSTANCE_NAME
     gcloud compute scp --recurse $INSTANCE_NAME ./RUN-${THIS_BENCHMARK}/
-    COMMAND="docker build BUILDING-${THIS_BENCHMARK}" # --build-arg dir=/dir
+    COMMAND="docker build RUN-${THIS_BENCHMARK}" # --build-arg dir=/dir
     gcloud compute ssh $INSTANCE_NAME --command=$COMMAND
   done
 done

--- a/engine_comparison/dispatcher.sh
+++ b/engine_comparison/dispatcher.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+. $(dirname $0)/../common.sh
+
+build_engine() {
+  # [[ ! -e ~/$FENGINE_CONFIGS_DIR/$1 ]] && echo "cant do" && exit 1
+  echo "Building $FUZZING_ENGINE"
+  # Probably use another script, to easily use env vars
+  #
+  # if libfuzzer
+  # if afl
+}
+
+build_benchmark_using() {
+  BENCHMARK=$1
+  FENGINE_CONFIG=$2
+  # . $FENGINE_CONFIG
+
+  BUILDING_DIR=RUN-${THIS_BENCHMARK}
+  rm -rf $BUILDING_DIR
+  mkdir $BUILDING_DIR
+  cd $BUILDING_DIR
+  echo "Filling $BUILDING_DIR"
+
+  # [[ ! -e ~/$FTS/$1/build.sh ]] && echo "cant build" && exit 1
+  ~/$FTS/$1/build.sh $FENGINE_NAME $FUZZING_ENGINE
+
+  # copy binaries
+
+  # TODO Add other items eg ./afl-fuzz, seeds
+}
+
+BASE_INSTANCE_NAME="FTS-RUNNER"
+EXPORT FENGINE_CONFIGS_DIR=${FENGINE_CONFIGS_DIR:-"fuzzing-engine-configs"}
+
+for FENGINE_CONFIG in $(find ~/$FENGINE_CONFIGS_DIR); do
+  build_engine $FUZZING_ENGINE
+  for BENCHMARK in $ALL_BENCHMARKS; do
+    THIS_BENCHMARK=${BENCHMARK}-${FUZZING_ENGINE}
+    # n.b. this requires each config file to have a different name
+    INSTANCE_NAME=${BASE_INSTANCE_NAME}-${THIS_BENCHMARK}
+    build_benchmark_using $BENCHMARK $FUZZING_ENGINE
+
+    gcloud compute instances create $INSTANCE_NAME
+    gcloud compute scp --recurse $INSTANCE_NAME ./RUN-${THIS_BENCHMARK}/
+    COMMAND="docker build BUILDING-${THIS_BENCHMARK}" # --build-arg dir=/dir
+    gcloud compute ssh $INSTANCE_NAME --command=$COMMAND
+  done
+done
+
+
+######
+# for time in 30s 1m 5m 10m 30m; do
+  # sleep $time
+  # echo "Information after sleeping $time"
+  # tail fuzz-0.log | echo
+# done


### PR DESCRIPTION
The dispatcher script loops through every binary which needs to be constructed, and (right now, just approximately) creates a runner VM to send the binary to.

The dockerfile will want to be `FROM` gcr.io, rather than base ubuntu, so that some of the packages will be installed ahead of time.