### PR TITLE
Config/autogen changes and fixes

### DIFF
--- a/engine-comparison/README.md
+++ b/engine-comparison/README.md
@@ -87,8 +87,8 @@ propagate directly to the environments for
 
 ## Parameters
 
-Script behavior can be modified through a set of parameters which are defined in 
-`parameters.cfg`. They're are assigned with default values, but they can be changed 
+Script behavior can be modified through a set of parameters which are defined in
+`parameters.cfg`. They are assigned with default values, but they can be changed
 by the user before running `begin-experiment.sh`. These parameters are:
 
 - `N_ITERATIONS`, the number of times each binary will be run (and measured).

--- a/engine-comparison/README.md
+++ b/engine-comparison/README.md
@@ -87,9 +87,9 @@ propagate directly to the environments for
 
 ## Parameters
 
-Script behavior can be modified through a variety of environment variables. This
-is a definitive list of options which have default values, but can be altered
-before running `begin-experiment.sh` for advanced users
+Script behavior can be modified through a set of parameters which are defined in 
+`parameters.cfg`. They're are assigned with default values, but they can be changed 
+by the user before running `begin-experiment.sh`. These parameters are:
 
 - `N_ITERATIONS`, the number of times each binary will be run (and measured).
 Each iteration will be run until the benchmark is completed, except with regards

--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -35,6 +35,7 @@ gcloud compute scp fengine-configs/ ${INSTANCE_NAME}:~/input --recurse
 rm -r fengine-configs
 
 CONFIG=${SCRIPT_DIR}/config
+[[ -e ${CONFIG}/bmarks.cfg ]] && rm ${CONFIG}/bmarks.cfg
 echo "BMARKS=$1" > ${CONFIG}/bmarks.cfg
 
 # Pass service account auth key

--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -34,28 +34,9 @@ done
 gcloud compute scp fengine-configs/ ${INSTANCE_NAME}:~/input --recurse
 rm -r fengine-configs
 
-# These will frequently/usually be defined by the user
-JOBS=${JOBS:-8}
-N_ITERATIONS=${N_ITERATIONS:-5}
-
-# Send configs
-AUTOGEN=${SCRIPT_DIR}/autogen
-
-if [[ ! -d $AUTOGEN ]]; then
-  mkdir $AUTOGEN
-fi
-
-if [[ ! -e ${AUTOGEN}/dispatcher.config ]]; then
-  echo "BMARKS=$1" > ${AUTOGEN}/dispatcher.config
-fi
-
-if [[ ! -e ${AUTOGEN}/worker.config ]]; then
-  echo "N_ITERATIONS=$N_ITERATIONS" > ${AUTOGEN}/worker.config
-  echo "JOBS=$JOBS" >> ${AUTOGEN}/worker.config
-fi
 # Pass service account auth key
-if [[ ! -e ${AUTOGEN}/dispatcher-key.json ]]; then
-  gcloud iam service-accounts keys create ${AUTOGEN}/dispatcher-key.json \
+if [[ ! -e ${SCRIPT_DIR}/autogen-PRIVATE-key.json ]]; then
+  gcloud iam service-accounts keys create ${SCRIPT_DIR}/autogen-PRIVATE-key.json \
     --iam-account=$SERVICE_ACCOUNT --key-file-type=json
 fi
 

--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -34,9 +34,12 @@ done
 gcloud compute scp fengine-configs/ ${INSTANCE_NAME}:~/input --recurse
 rm -r fengine-configs
 
+CONFIG=${SCRIPT_DIR}/config
+echo "BMARKS=$1" > ${CONFIG}/bmarks.cfg
+
 # Pass service account auth key
-if [[ ! -e ${SCRIPT_DIR}/autogen-PRIVATE-key.json ]]; then
-  gcloud iam service-accounts keys create ${SCRIPT_DIR}/autogen-PRIVATE-key.json \
+if [[ ! -e ${CONFIG}/autogen-PRIVATE-key.json ]]; then
+  gcloud iam service-accounts keys create ${CONFIG}/autogen-PRIVATE-key.json \
     --iam-account=$SERVICE_ACCOUNT --key-file-type=json
 fi
 

--- a/engine-comparison/config/parameters.cfg
+++ b/engine-comparison/config/parameters.cfg
@@ -1,3 +1,2 @@
-BMARKS=small
 N_ITERATIONS=5
 JOBS=8

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -63,12 +63,12 @@ mkdir $WORK/fuzz-engines
 
 # Stripped down equivalent of "gcloud init"
 gcloud auth activate-service-account $SERVICE_ACCOUNT \
-  --key-file="$WORK/FTS/engine-comparison/autogen-PRIVATE-key.json"
+  --key-file="$WORK/FTS/engine-comparison/config/autogen-PRIVATE-key.json"
 gcloud config set project fuzzer-test-suite
 
 
 # This config file defines $BMARKS
-. $WORK/FTS/engine-comparison/parameters.cfg
+. $WORK/FTS/engine-comparison/config/bmarks.cfg
 # Now define $BENCHMARKS
 if [[ $BMARKS == 'all' ]]; then
   for b in $(find ${SCRIPT_DIR}/../*/build.sh -type f); do

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -63,12 +63,12 @@ mkdir $WORK/fuzz-engines
 
 # Stripped down equivalent of "gcloud init"
 gcloud auth activate-service-account $SERVICE_ACCOUNT \
-  --key-file="$WORK/FTS/engine-comparison/autogen/dispatcher-key.json"
+  --key-file="$WORK/FTS/engine-comparison/autogen-PRIVATE-key.json"
 gcloud config set project fuzzer-test-suite
 
 
 # This config file defines $BMARKS
-. $WORK/FTS/engine-comparison/autogen/dispatcher.config
+. $WORK/FTS/engine-comparison/parameters.cfg
 # Now define $BENCHMARKS
 if [[ $BMARKS == 'all' ]]; then
   for b in $(find ${SCRIPT_DIR}/../*/build.sh -type f); do

--- a/engine-comparison/parameters.cfg
+++ b/engine-comparison/parameters.cfg
@@ -1,0 +1,3 @@
+BMARKS=small
+N_ITERATIONS=5
+JOBS=8


### PR DESCRIPTION
Rather than generating a file from env vars, we should just have the file in the repo. 

Also, I changed the name of the key.json; hopefully, it is now less likely that someone accidentally commits their local autogen copy to github.

It may make sense to remove benchmarks as a parameter, for code simplicity, but that would change the `begin-experiment` args so it may be unnecessary