### PR TITLE
Build fuzzers in dispatcher

### DIFF
--- a/common.sh
+++ b/common.sh
@@ -15,7 +15,6 @@ FUZZING_ENGINE=${FUZZING_ENGINE:-"libfuzzer"}
 SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)-${FUZZING_ENGINE}
 LIBFUZZER_SRC=${LIBFUZZER_SRC:-$(dirname $(dirname $SCRIPT_DIR))/Fuzzer}
-AFL_DRIVER=$LIBFUZZER_SRC/afl/afl_driver.cpp
 AFL_SRC=${AFL_SRC:-$(dirname $(dirname $SCRIPT_DIR))/AFL}
 FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div"
 CORPUS=CORPUS-$EXECUTABLE_NAME_BASE
@@ -52,8 +51,8 @@ get_svn_revision() {
 
 build_afl() {
   $CC $CFLAGS -c -w $AFL_SRC/llvm_mode/afl-llvm-rt.o.c
-  $CXX $CXXFLAGS -std=c++11 -O2 -c $LIBFUZZER_SRC/afl/*.cpp -I$LIBFUZZER_SRC
-  ar r $LIB_FUZZING_ENGINE *.o
+  $CXX $CXXFLAGS -std=c++11 -O2 -c ${LIBFUZZER_SRC}/afl/afl_driver.cpp -I$LIBFUZZER_SRC
+  ar r $LIB_FUZZING_ENGINE afl_driver.o afl-llvm-rt.o.o
   rm *.o
 }
 

--- a/common.sh
+++ b/common.sh
@@ -14,7 +14,7 @@ FUZZING_ENGINE=${FUZZING_ENGINE:-"libfuzzer"}
 
 SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)-${FUZZING_ENGINE}
-LIBFUZZER_SRC=$(dirname $(dirname $SCRIPT_DIR))/Fuzzer
+LIBFUZZER_SRC=${LIBFUZZER_SRC:-$(dirname $(dirname $SCRIPT_DIR))/Fuzzer}
 AFL_SRC=${AFL_SRC:-$(dirname $(dirname $SCRIPT_DIR))/AFL}
 FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div,pc-table"
 CORPUS=CORPUS-$EXECUTABLE_NAME_BASE

--- a/common.sh
+++ b/common.sh
@@ -16,7 +16,7 @@ SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)-${FUZZING_ENGINE}
 LIBFUZZER_SRC=$(dirname $(dirname $SCRIPT_DIR))/Fuzzer
 AFL_SRC=${AFL_SRC:-$(dirname $(dirname $SCRIPT_DIR))/AFL}
-FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div"
+FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div,pc-table"
 CORPUS=CORPUS-$EXECUTABLE_NAME_BASE
 JOBS=8
 

--- a/common.sh
+++ b/common.sh
@@ -14,9 +14,9 @@ FUZZING_ENGINE=${FUZZING_ENGINE:-"libfuzzer"}
 
 SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)-${FUZZING_ENGINE}
-LIBFUZZER_SRC=$(dirname $(dirname $SCRIPT_DIR))/Fuzzer
+LIBFUZZER_SRC=${LIBFUZZER_SRC:-$(dirname $(dirname $SCRIPT_DIR))/Fuzzer}
 AFL_DRIVER=$LIBFUZZER_SRC/afl/afl_driver.cpp
-AFL_SRC=$(dirname $(dirname $SCRIPT_DIR))/AFL
+AFL_SRC=${AFL_SRC:-$(dirname $(dirname $SCRIPT_DIR))/AFL}
 FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div"
 CORPUS=CORPUS-$EXECUTABLE_NAME_BASE
 JOBS=8

--- a/common.sh
+++ b/common.sh
@@ -14,7 +14,7 @@ FUZZING_ENGINE=${FUZZING_ENGINE:-"libfuzzer"}
 
 SCRIPT_DIR=$(dirname $0)
 EXECUTABLE_NAME_BASE=$(basename $SCRIPT_DIR)-${FUZZING_ENGINE}
-LIBFUZZER_SRC=${LIBFUZZER_SRC:-$(dirname $(dirname $SCRIPT_DIR))/Fuzzer}
+LIBFUZZER_SRC=$(dirname $(dirname $SCRIPT_DIR))/Fuzzer
 AFL_SRC=${AFL_SRC:-$(dirname $(dirname $SCRIPT_DIR))/AFL}
 FUZZ_CXXFLAGS="-O2 -fno-omit-frame-pointer -g -fsanitize=address -fsanitize-coverage=trace-pc-guard,trace-cmp,trace-gep,trace-div"
 CORPUS=CORPUS-$EXECUTABLE_NAME_BASE

--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -18,7 +18,7 @@ INSTANCE_NAME="dispatcher-${DD}-${MM}"
 # echo "Restarting gcloud instance. Instance should already be created (with gcloud_creator.sh)"
 create_or_start $INSTANCE_NAME
 robust_begin_gcloud_ssh $INSTANCE_NAME
-gcloud compute ssh $INSTANCE_NAME --command="mkdir ~/input"
+gcloud compute ssh $INSTANCE_NAME --command="rm -fr ~/input/fengine-configs && mkdir ~/input"
 
 # Send configs for the fuzzing engine
 FENGINE_CONFIGS=${@:2}

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -9,8 +9,10 @@
 build_engine() {
 
   FENGINE_CONFIG=$1
-  [[ ! -e $FENGINE_CONFIG ]] && echo "File DNE" && exit 1
-  echo "Building $FENGINE_CONFIG"
+  [[ ! -e $FENGINE_CONFIG ]] && echo \
+    "Error: build_engine function called for FENGINE_CONFIG=$FENGINE_CONFIG,\
+    but this file can't be found" && return
+  echo "Creating fuzzing engine: $FENGINE_CONFIG"
   FENGINE_NAME=$(basename $FENGINE_CONFIG)
   FENGINE_DIR=$WORK/fengine-builds/${FENGINE_NAME}
   rm -rf $FENGINE_DIR
@@ -20,19 +22,17 @@ build_engine() {
   # Build either engine
 
   if [[ $FUZZING_ENGINE == "libfuzzer" ]]; then
-    echo "Making a version of libfuzzer"
+    echo "Checking out libFuzzer"
     svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer $FENGINE_DIR
     export LIBFUZZER_SRC=$FENGINE_DIR
-  fi
 
-  if [[ $FUZZING_ENGINE == "afl" ]]; then
-
+  elif [[ $FUZZING_ENGINE == "afl" ]]; then
     # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break
     if [[ ! -d $LIBFUZZER_SRC ]]; then
       mkdir -p ${LIBFUZZER_SRC}/afl
       svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer/afl ${LIBFUZZER_SRC}/afl
     fi
-    echo "Making a version of afl"
+    echo "Building a version of AFL"
     cd $WORK/fengine-builds
     wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz
     mkdir $FENGINE_DIR

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -26,6 +26,8 @@ build_engine() {
   fi
 
   if [[ $FUZZING_ENGINE == "afl" ]]; then
+
+    # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break
     echo "Making a version of afl"
     cd $WORK/fengine-builds
     wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz
@@ -34,6 +36,7 @@ build_engine() {
     (cd $FENGINE_DIR && make)
     rm afl-latest.tgz
     cd
+    export AFL_SRC=$FENGINE_DIR
   fi
 }
 

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -28,6 +28,10 @@ build_engine() {
   if [[ $FUZZING_ENGINE == "afl" ]]; then
 
     # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break
+    if [[ ! -d $LIBFUZZER_SRC ]]; then
+      mkdir -p ${LIBFUZZER_SRC}/afl
+      svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer/afl ${LIBFUZZER_SRC}/afl
+     fi
     echo "Making a version of afl"
     cd $WORK/fengine-builds
     wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -11,7 +11,7 @@ build_engine() {
   FENGINE_CONFIG=$1
   [[ ! -e $FENGINE_CONFIG ]] && echo \
     "Error: build_engine function called for FENGINE_CONFIG=$FENGINE_CONFIG,\
-    but this file can't be found" && return
+    but this file can't be found" && exit 1
   echo "Creating fuzzing engine: $FENGINE_CONFIG"
   FENGINE_NAME=$(basename $FENGINE_CONFIG)
   FENGINE_DIR=$WORK/fengine-builds/${FENGINE_NAME}
@@ -25,7 +25,8 @@ build_engine() {
 
     if [[ ! -d ${LIBFUZZER_SRC}/standalone ]]; then
       echo "Checking out libFuzzer"
-      svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer
+      svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer $WORK/Fuzzer
+      LIBFUZZER_SRC=$WORK/Fuzzer
     fi
 
   elif [[ $FUZZING_ENGINE == "afl" ]]; then
@@ -37,7 +38,6 @@ build_engine() {
     echo "Building a version of AFL"
     cd $WORK/fengine-builds
     wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz
-    mkdir $FENGINE_DIR
     tar -xvf afl-latest.tgz -C $FENGINE_DIR --strip-components=1
     (cd $FENGINE_DIR && make)
     rm afl-latest.tgz

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -31,7 +31,7 @@ build_engine() {
     if [[ ! -d $LIBFUZZER_SRC ]]; then
       mkdir -p ${LIBFUZZER_SRC}/afl
       svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer/afl ${LIBFUZZER_SRC}/afl
-     fi
+    fi
     echo "Making a version of afl"
     cd $WORK/fengine-builds
     wget http://lcamtuf.coredump.cx/afl/releases/afl-latest.tgz

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -24,7 +24,6 @@ build_engine() {
   if [[ $FUZZING_ENGINE == "libfuzzer" ]]; then
     echo "Checking out libFuzzer"
     svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer
-  fi
 
   elif [[ $FUZZING_ENGINE == "afl" ]]; then
     # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -5,7 +5,6 @@
 . $(dirname $0)/../common.sh
 . ${SCRIPT_DIR}/common-harness.sh
 
-# Each of these functions should be in a separate script
 
 build_engine() {
 

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -22,8 +22,11 @@ build_engine() {
   # Build either engine
 
   if [[ $FUZZING_ENGINE == "libfuzzer" ]]; then
-    echo "Checking out libFuzzer"
-    svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer
+
+    if [[ ! -d ${LIBFUZZER_SRC}/standalone ]]; then
+      echo "Checking out libFuzzer"
+      svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer
+    fi
 
   elif [[ $FUZZING_ENGINE == "afl" ]]; then
     # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -28,7 +28,7 @@ build_engine() {
 
   elif [[ $FUZZING_ENGINE == "afl" ]]; then
     # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break
-    if [[ ! -d $LIBFUZZER_SRC ]]; then
+    if [[ ! -d ${LIBFUZZER_SRC}/afl ]]; then
       mkdir -p ${LIBFUZZER_SRC}/afl
       svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer/afl ${LIBFUZZER_SRC}/afl
     fi

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -110,7 +110,7 @@ if [[ $BMARKS == 'all' ]]; then
     BENCHMARKS="$BENCHMARKS $(basename $(dirname $b))"
   done
 elif [[ $BMARKS == 'small' ]]; then
-  BENCHMARKS="boringssl-2016-02-12 re2-2014-12-09"
+  BENCHMARKS="c-ares-CVE-2016-5180 re2-2014-12-09"
 elif [[ $BMARKS == 'none' ]]; then
   BENCHMARKS=""
   #elif [[ $BMARKS == 'other alias' ]]; do

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -23,8 +23,8 @@ build_engine() {
 
   if [[ $FUZZING_ENGINE == "libfuzzer" ]]; then
     echo "Checking out libFuzzer"
-    svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer $FENGINE_DIR
-    export LIBFUZZER_SRC=$FENGINE_DIR
+    svn co http://llvm.org/svn/llvm-project/llvm/trunk/lib/Fuzzer
+  fi
 
   elif [[ $FUZZING_ENGINE == "afl" ]]; then
     # [[ ! -d $LIBFUZZER_SRC ]] && echo "Can't do AFL before libfuzzer" && break

--- a/engine-comparison/run.sh
+++ b/engine-comparison/run.sh
@@ -3,4 +3,4 @@
 cd
 sudo gcloud docker -- pull gcr.io/fuzzer-test-suite/gcloud-clang-deps
 sudo docker build -t base-image -f ~/input/FTS/engine-comparison/Dockerfile ~/input
-sudo docker run base-image "$1"
+sudo docker run --cap-add SYS_PTRACE base-image "$1"


### PR DESCRIPTION
This PR primarily completes the functions `build_engine` and `build_benchmark_using`; most other changes were bugs found while trying to make everything work.

With this code, `begin-experiment.sh all` can build almost all binaries and send them to google storage. "Almost all" because I've encountered a couple random builds on specific fengine/bmark combinations; I'm working through these now.