### PR TITLE
Rsync for begin-experiment

### DIFF
--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -32,12 +32,13 @@ fi
 
 # -m parallelizes operation; -r sets recursion, -d syncs deletion of files
 gsutil -m rsync -rd fengine-configs ${GSUTIL_BUCKET}/dispatcher-input/fengine-configs
-#r m -r fengine-configs
+rm -r fengine-configs
+
 # Send the entire local FTS repository to the dispatcher;
 # Local changes to any file will propagate
 gsutil -m rsync -rd $(dirname $SCRIPT_DIR) ${GSUTIL_BUCKET}/dispatcher-input/FTS
 
-gsutil -m acl ch -r -u ${SERVICE_ACCOUNT}:O ${GSUTIL_BUCKET}
+#gsutil -m acl ch -r -u ${SERVICE_ACCOUNT}:O ${GSUTIL_BUCKET}
 
 DD=$(date +%d)
 MM=$(date +%m)
@@ -46,12 +47,7 @@ INSTANCE_NAME="dispatcher-${DD}-${MM}"
 create_or_start $INSTANCE_NAME # $SCRIPT_DIR/dispatcher-startup.sh
 robust_begin_gcloud_ssh $INSTANCE_NAME
 
-#rsync -rpd fengine-configs ${INSTANCE_NAME}/home/fengine-configs
-#rm -r fengine-configs
-#rsync -rdp $(dirname $SCRIPT_DIR) ${INSTANCE_NAME}/home/FTS
-
 #gcloud compute ssh $INSTANCE_NAME --command="/home/input/FTS/engine-comparison/dispatcher-startup.sh "
-
 gcloud compute ssh $INSTANCE_NAME \
   --command="mkdir -p ~/input && gsutil -m rsync -rd gs://fuzzer-test-suite/dispatcher-input ~/input \
  && bash ~/input/FTS/engine-comparison/dispatcher-startup.sh"

--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -48,7 +48,7 @@ create_or_start $INSTANCE_NAME # $SCRIPT_DIR/dispatcher-startup.sh
 robust_begin_gcloud_ssh $INSTANCE_NAME
 
 gcloud compute ssh $INSTANCE_NAME \
-  --command="mkdir -p ~/input && gsutil -m rsync -rd gs://fuzzer-test-suite/dispatcher-input ~/input \
+  --command="mkdir -p ~/input && gsutil -m rsync -rd ${GSUTIL_BUCKET}/dispatcher-input ~/input \
  && bash ~/input/FTS/engine-comparison/dispatcher-startup.sh"
  # && chown --reference=/home ~/input
 

--- a/engine-comparison/begin-experiment.sh
+++ b/engine-comparison/begin-experiment.sh
@@ -47,7 +47,6 @@ INSTANCE_NAME="dispatcher-${DD}-${MM}"
 create_or_start $INSTANCE_NAME # $SCRIPT_DIR/dispatcher-startup.sh
 robust_begin_gcloud_ssh $INSTANCE_NAME
 
-#gcloud compute ssh $INSTANCE_NAME --command="/home/input/FTS/engine-comparison/dispatcher-startup.sh "
 gcloud compute ssh $INSTANCE_NAME \
   --command="mkdir -p ~/input && gsutil -m rsync -rd gs://fuzzer-test-suite/dispatcher-input ~/input \
  && bash ~/input/FTS/engine-comparison/dispatcher-startup.sh"

--- a/engine-comparison/dispatcher-startup.sh
+++ b/engine-comparison/dispatcher-startup.sh
@@ -1,13 +1,16 @@
-#! /bin/bash
+#!/bin/bash
 # Copyright 2017 Google Inc. All Rights Reserved.
 # Licensed under the Apache License, Version 2.0 (the "License");
 
-cd
-[[ ! -d /input ]] && mkdir /input
-
-gsutil -m rsync -rd gs://fuzzer-test-suite/dispatcher-input /input
-gcloud docker -- pull gcr.io/fuzzer-test-suite/gcloud-clang-deps
-
-sudo docker build -t base-image -f /input/FTS/engine-comparison/Dockerfile /input
+sudo gcloud docker -- pull gcr.io/fuzzer-test-suite/gcloud-clang-deps
+for f in $(find ~/input/FTS/*.sh);
+do
+  chmod 750 $f
+done
+for f in $(find ~/input/FTS/*/*.sh);
+do
+  chmod 750 $f
+done
+sudo docker build -t base-image -f ~/input/FTS/engine-comparison/Dockerfile ~/input
 sudo docker run --cap-add SYS_PTRACE base-image /work/FTS/engine-comparison/dispatcher.sh
 

--- a/engine-comparison/dispatcher-startup.sh
+++ b/engine-comparison/dispatcher-startup.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+# Copyright 2017 Google Inc. All Rights Reserved.
+# Licensed under the Apache License, Version 2.0 (the "License");
+
+cd
+[[ ! -d /input ]] && mkdir /input
+
+gsutil -m rsync -rd gs://fuzzer-test-suite/dispatcher-input /input
+gcloud docker -- pull gcr.io/fuzzer-test-suite/gcloud-clang-deps
+
+sudo docker build -t base-image -f /input/FTS/engine-comparison/Dockerfile /input
+sudo docker run --cap-add SYS_PTRACE base-image /work/FTS/engine-comparison/dispatcher.sh
+

--- a/engine-comparison/run.sh
+++ b/engine-comparison/run.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-cd
-sudo gcloud docker -- pull gcr.io/fuzzer-test-suite/gcloud-clang-deps
-sudo docker build -t base-image -f ~/input/FTS/engine-comparison/Dockerfile ~/input
-sudo docker run --cap-add SYS_PTRACE base-image "$1"


### PR DESCRIPTION
Addresses #47 ; Multiple `scp` and `ssh` commands were consolidated into `dispatcher-startup.sh`, which is now called in a single `ssh`. It could be assigned as a startup script, but this forgoes the benefit of seeing output from the dispatcher VM.

The benefit of reduced bandwidth via `rsync` is in contrast, somewhat, with file permission headaches.