### PR TITLE
Clean up time management

### DIFF
--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -134,7 +134,9 @@ elif [[ $BMARKS == 'small' ]]; then
   BENCHMARKS="c-ares-CVE-2016-5180 re2-2014-12-09"
 elif [[ $BMARKS == 'none' ]]; then
   BENCHMARKS=""
-  #elif [[ $BMARKS == 'other alias' ]]; do
+elif [[ $BMARKS == 'three' ]]; then
+  BENCHMARKS="guetzli-2017-3-30 libssh-2017-1272 re2-2014-12-09"
+#elif [[ $BMARKS == 'other alias' ]]; then
 else
   BENCHMARKS="$(echo $BMARKS | tr ',' ' ')"
 fi
@@ -178,9 +180,10 @@ measure_coverage () {
   FENGINE_NAME=$(basename $FENGINE_CONFIG)
   BENCHMARK=$2
 
-  CORPUS_DIR=$WORK/measurement-folders/$BENCHMARK/corpus
-  SANCOV_DIR=$WORK/measurement-folders/$BENCHMARK/sancovs
-  REPORT_DIR=$WORK/measurement-folders/$BENCHMARK/reports
+  THIS_BENCHMARK="${BENCHMARK}/${FENGINE_NAME}"
+  CORPUS_DIR=$WORK/measurement-folders/$THIS_BENCHMARK/corpus
+  SANCOV_DIR=$WORK/measurement-folders/$THIS_BENCHMARK/sancovs
+  REPORT_DIR=$WORK/measurement-folders/$THIS_BENCHMARK/reports
 
   EXPERIMENT_DIR=$WORK/experiment-folders/${BENCHMARK}-${FENGINE_NAME}
 
@@ -195,6 +198,9 @@ measure_coverage () {
   fi
 
   THIS_CYCLE=$(($LATEST_REPORT + 1))
+  while [[ $(grep "^${THIS_CYCLE}$" ${EXPERIMENT_DIR}/results/skipped-cycles) ]]; do
+    THIS_CYCLE=$((THIS_CYCLE + 1))
+  done
   if [[ ! -f ${EXPERIMENT_DIR}/corpus/corpus-archive-${THIS_CYCLE}.tar.gz ]]; then
     echo "On cycle $THIS_CYCLE, no new corpus found for benchmark $BENCHMARK and fengine $FENGINE_NAME"
     return
@@ -217,14 +223,14 @@ measure_coverage () {
   # Could include calls to external scripts in Golang, HTML, etc
 
   # declare VM_SECONDS
-  . $EXPERIMENT_DIR/results/seconds-${THIS_CYCLE}
+  # . $EXPERIMENT_DIR/results/seconds-${THIS_CYCLE}
 
-  echo "$VM_SECONDS, $($WORK/coverage-builds/sancov.py print $SANCOV_DIR/* | wc -w)" >> $REPORT_DIR/coverage-graph.csv
-  echo "$VM_SECONDS, $(wc -c $(find $CORPUS_DIR -maxdepth 1 -type f) | tail --lines=1 | grep -o [0-9]* )" >> $REPORT_DIR/corpus-size-graph.csv
-  echo "$VM_SECONDS, $(find $CORPUS_DIR -maxdepth 1 -type f | wc -l)" >> $REPORT_DIR/corpus-elems-graph.csv
+  echo "$THIS_CYCLE,$($WORK/coverage-builds/sancov.py print $SANCOV_DIR/* | wc -w)" >> $REPORT_DIR/coverage-graph.csv
+  echo "$THIS_CYCLE,$(wc -c $(find $CORPUS_DIR -maxdepth 1 -type f) | tail --lines=1 | grep -o [0-9]* )" >> $REPORT_DIR/corpus-size-graph.csv
+  echo "$THIS_CYCLE,$(find $CORPUS_DIR -maxdepth 1 -type f | wc -l)" >> $REPORT_DIR/corpus-elems-graph.csv
 
   echo "LATEST_REPORT=$THIS_CYCLE" > $REPORT_DIR/latest-report
-  gsutil -m rsync -rd $REPORT_DIR ${GSUTIL_BUCKET}/reports/${BENCHMARK}
+  gsutil -m rsync -rd $REPORT_DIR ${GSUTIL_BUCKET}/reports/${BENCHMARK}/${FENGINE_NAME}
 }
 
 mkdir -p $WORK/coverage-builds

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -135,8 +135,7 @@ elif [[ $BMARKS == 'small' ]]; then
 elif [[ $BMARKS == 'none' ]]; then
   BENCHMARKS=""
 elif [[ $BMARKS == 'three' ]]; then
-  BENCHMARKS="guetzli-2017-3-30 libssh-2017-1272 re2-2014-12-09"
-#elif [[ $BMARKS == 'other alias' ]]; then
+  BENCHMARKS="guetzli-2017-3-30 libarchive-2017-01-04 openssl-1.0.1f"
 else
   BENCHMARKS="$(echo $BMARKS | tr ',' ' ')"
 fi
@@ -222,15 +221,12 @@ measure_coverage () {
   # Report generation goes >here<
   # Could include calls to external scripts in Golang, HTML, etc
 
-  # declare VM_SECONDS
-  # . $EXPERIMENT_DIR/results/seconds-${THIS_CYCLE}
-
   echo "$THIS_CYCLE,$($WORK/coverage-builds/sancov.py print $SANCOV_DIR/* | wc -w)" >> $REPORT_DIR/coverage-graph.csv
   echo "$THIS_CYCLE,$(wc -c $(find $CORPUS_DIR -maxdepth 1 -type f) | tail --lines=1 | grep -o [0-9]* )" >> $REPORT_DIR/corpus-size-graph.csv
   echo "$THIS_CYCLE,$(find $CORPUS_DIR -maxdepth 1 -type f | wc -l)" >> $REPORT_DIR/corpus-elems-graph.csv
 
   echo "LATEST_REPORT=$THIS_CYCLE" > $REPORT_DIR/latest-report
-  gsutil -m rsync -rd $REPORT_DIR ${GSUTIL_BUCKET}/reports/${BENCHMARK}/${FENGINE_NAME}
+  gsutil -m rsync -rd $REPORT_DIR ${GSUTIL_BUCKET}/reports/${THIS_BENCHMARK}
 }
 
 mkdir -p $WORK/coverage-builds

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -12,8 +12,7 @@ FENGINE_NAME=$(curl http://metadata.google.internal/computeMetadata/v1/instance/
 BINARY=${BENCHMARK}-${FUZZING_ENGINE}
 
 rm -fr corpus results
-mkdir corpus
-mkdir results
+mkdir corpus results
 # seeds comes from dispatcher.sh, if it exists
 chmod 750 $BINARY
 
@@ -50,25 +49,29 @@ mkdir corpus-archives
 SYNC_TO=${BENCHMARK}-${FENGINE_NAME}
 # WAIT_PERIOD should be longer than the whole loop, otherwise a sync cycle will be missed
 WAIT_PERIOD=20
+# "cycle 0" will be "time 0", and for purposes is skipped
 CYCLE=1
 
 # Now, begin
 $EXEC_CMD
-NEXT_SYNC=$(($SECONDS + $WAIT_PERIOD)) # =$SECONDS # Make beginning measurement?
-
-# This works for libfuzzer, tbd for AFL:
-while [[ ! -f crash* ]]; do
-# while [[ "infinite loop" ]]; do
+# Setting SECONDS is fine, it still gets ++ on schedule
+SECONDS=0
+NEXT_SYNC=$WAIT_PERIOD
+# This doesn't work for leaks or timeouts, as they have different names:
+# Currently only the individual copies of test-libfuzzer.sh document
+# the particulars of how to identify complete benchmarks
+while [[ ! $(ls | grep crash) ]]; do
 
   # Ensure that measurements happen every $WAIT_PERIOD
   SLEEP_TIME=$(($NEXT_SYNC - $SECONDS))
+  # if $NEXT_SYNC
   sleep $SLEEP_TIME
 
   # Snapshot
   cp -r corpus corpus-copy
 
   echo "VM_SECONDS=$SECONDS" > results/seconds-${CYCLE}
-  ls -l corpus-copy > results/corpus-data-${CYCLE}
+  # ls -l corpus-copy > results/corpus-data-${CYCLE}
   tar -cvzf corpus-archives/corpus-archive-${CYCLE}.tar.gz corpus-copy
   gsutil -m rsync -rPd results gs://fuzzer-test-suite/experiment-folders/${SYNC_TO}/results
   gsutil -m rsync -rPd corpus-archives gs://fuzzer-test-suite/experiment-folders/${SYNC_TO}/corpus
@@ -76,11 +79,14 @@ while [[ ! -f crash* ]]; do
   # Done with snapshot
   rm -r corpus-copy
 
+  CYCLE=$(($CYCLE + 1))
+  NEXT_SYNC=$(($CYCLE * $WAIT_PERIOD))
   # Skip cycle if need be
   while [[ $(($NEXT_SYNC < $SECONDS)) == 1 ]]; do
-    NEXT_SYNC=$(($NEXT_SYNC + $WAIT_PERIOD))
+    echo "$CYCLE" >> results/skipped-cycles
+    CYCLE=$(($CYCLE + 1))
+    NEXT_SYNC=$(($CYCLE * $WAIT_PERIOD))
   done
 
-  CYCLE=$(($CYCLE + 1))
 done
 

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -57,14 +57,13 @@ $EXEC_CMD
 # Setting SECONDS is fine, it still gets ++ on schedule
 SECONDS=0
 NEXT_SYNC=$WAIT_PERIOD
-# This doesn't work for leaks or timeouts, as they have different names:
-# Currently only the individual copies of test-libfuzzer.sh document
-# the particulars of how to identify complete benchmarks
+# This doesn't work for leaks or timeouts, as they have different artifact
+# names. Currently, only the individual copies of test-libfuzzer.sh document
+# the particulars of how to identify when each benchmark finds its goal
 while [[ ! $(ls | grep crash) ]]; do
 
   # Ensure that measurements happen every $WAIT_PERIOD
   SLEEP_TIME=$(($NEXT_SYNC - $SECONDS))
-  # if $NEXT_SYNC
   sleep $SLEEP_TIME
 
   # Snapshot


### PR DESCRIPTION
Most of this code transitions the units of time from seconds to cycles, which makes our data more consistent. The previous code created `csv`s which were difficult to graph, because intervals would be effectively randomly sampled from 19,20, and 21.

Because the periods of corpus snapshots are regulated so successfully, and margins of error in my experiments now never exceed 1 second, this is justified. In particular, because time is tracked with `$SECONDS`, an offset of 1 second isn't a useful nuance to record and graph. 

As a failsafe, seconds are still recorded, and they will be processed by the golang parser to ensure nothing crazy happens.