### PR TITLE
Report generator: CSV parsing and HTML frame

### DIFF
--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -50,9 +50,11 @@ func composeAllNamed(desired_report_fname string) {
 	bmarks, err := ioutil.ReadDir(master_path)
 	checkErr(err)
 	for _, bmark := range bmarks {
-		// all_fe_file, _ := os.Create(path.Join(master_path, bmark.Name(), desired_report_fname))
+		// all_fe_file, err := os.Create(path.Join(master_path, bmark.Name(), desired_report_fname))
+		// checkErr(err)
 		// defer all_fe_file.Close()
 		// all_fe_writer := csv.NewWriter(all_fe_file)
+		// meta_records := [][]string{{"time"}}
 		potential_fengines, err := ioutil.ReadDir(path.Join(master_path, bmark.Name()))
 		checkErr(err)
 		// narrow potential_fengines to fengines so the indices of `range fengines` are useful
@@ -69,7 +71,8 @@ func composeAllNamed(desired_report_fname string) {
 			records := [][]string{{"time"}}
 
 			// Enter sub-directories
-			potential_trials, _ := ioutil.ReadDir(path.Join(master_path, bmark.Name(), fengine.Name()))
+			potential_trials, err := ioutil.ReadDir(path.Join(master_path, bmark.Name(), fengine.Name()))
+			checkErr(err)
 			trials := onlyDirectories(potential_trials)
 
 			num_record_columns := len(trials) + 1

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -120,7 +120,7 @@ func appendFastestTrial(meta_records [][]string, records [][]string) [][]string 
 	}
 
 	// Update meta_records
-	if len(meta_records) < speed_of_ft {
+	if len(meta_records) < speed_of_ft+1 {
 		meta_records = extendRecordsToTime(meta_records, speed_of_ft, len(meta_records[0]))
 	}
 	for j := 0; j <= speed_of_ft; j++ {

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+        "fmt"
+//        "io"
+	"path"
+        "io/ioutil"
+//        "strings"
+        "strconv"
+        "encoding/csv"
+        "os"
+)
+func checkErr(e error){
+	if (e != nil) {
+		fmt.Println("POOP!")
+		os.Exit(1)
+	}
+}
+
+// Removes non-directory elements of any []os.FileInfo (a helper function, for convenience)
+// Makes use of idiomatic Golang return: out_ls is declared and returned implicitly
+func onlyDirectories(potential_files []os.FileInfo) (out_ls []os.FileInfo) {
+	for _, fd := range potential_files {
+		if fd.IsDir() {
+			out_ls = append(out_ls, fd)
+		}
+	}
+	return
+}
+
+// Extend "records" matrix to have rows until time "desired_time"
+// Return: Extended version of record
+func extendRecordsToTime(records [][]string, desired_time int, recordCols int) ([][]string)  {
+	lenr := len(records)
+	for j := lenr; j < desired_time + 1; j++ {
+		records = append(records, make([]string, recordCols))
+		records[j][0] = strconv.Itoa(j)
+		for k := 1; k < recordCols; k++ {
+			records[j][k] = ""
+		}
+	}
+	return records
+}
+
+// Enters all report subdirectories, from benchmark to fengine to trial;
+// composes individual CSVs (only two columns) into larger CSVs
+func composeAllNamed(desired_report_fname string) {
+	master_path := "./reports"
+	bmarks, err := ioutil.ReadDir(master_path)
+	checkErr(err)
+	for _, bmark := range bmarks {
+		// all_fe_file, _ := os.Create(path.Join(master_path, bmark.Name(), desired_report_fname))
+		// defer all_fe_file.Close()
+		// all_fe_writer := csv.NewWriter(all_fe_file)
+		potential_fengines, err := ioutil.ReadDir(path.Join(master_path, bmark.Name()))
+		checkErr(err)
+		// narrow potential_fengines to fengines so the indices of `range fengines` are useful
+		fengines := onlyDirectories(potential_fengines)
+
+		for _, fengine := range fengines {
+			// Create fds
+			this_fe_file, err := os.Create(path.Join(master_path, bmark.Name(), fengine.Name(), desired_report_fname))
+			checkErr(err)
+			defer this_fe_file.Close()
+			this_fe_writer := csv.NewWriter(this_fe_file)
+
+			// Create matrix, to eventually become a CSV
+			records := [][]string{{"time"}}
+
+			// Enter sub-directories
+			potential_trials, _ := ioutil.ReadDir(path.Join(master_path, bmark.Name(), fengine.Name()))
+			trials := onlyDirectories(potential_trials)
+
+			num_record_columns := len(trials) + 1
+			for j, trial := range trials {
+				// Create fds
+				this_file, err := os.Open(path.Join(master_path, bmark.Name(), fengine.Name(), trial.Name(), desired_report_fname))
+				checkErr(err)
+				defer this_file.Close()
+				this_reader := csv.NewReader(this_file)
+
+				experiment_records, err := this_reader.ReadAll()
+				checkErr(err)
+				records[0] = append(records[0], fengine.Name() + trial.Name())
+
+				for _, row := range experiment_records {
+					time_now, err := strconv.Atoi(row[0])
+					checkErr(err)
+					//If this test went longer than all of the others, so far
+					if(len(records) < time_now + 1) {
+						records = extendRecordsToTime(records, time_now, num_record_columns)
+					}
+					records[time_now][j+1] = row[1]
+				}
+				this_fe_writer.WriteAll(records)
+			}
+			// TODO: create comparison between fengines, having already composed trials
+			// Do this by identifying the max (or potentially median) performing trial
+			// For each fengine, and putting them all into a CSV which can be graphed
+		}
+	}
+}
+
+func main(){
+	composeAllNamed("coverage-graph.csv")
+	composeAllNamed("corpus-size-graph.csv")
+	composeAllNamed("corpus-elems-graph.csv")
+	// createIFramesFor("setOfFrames.html")
+	// <iframe width="960" height="500" src="benchmarkN/report.html" frameborder="0"></iframe>
+}
+
+
+

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -1,17 +1,18 @@
 package main
 
 import (
-        "fmt"
-//        "io"
+	"fmt"
+	//        "io"
+	"io/ioutil"
 	"path"
-        "io/ioutil"
-//        "strings"
-        "strconv"
-        "encoding/csv"
-        "os"
+	//        "strings"
+	"encoding/csv"
+	"os"
+	"strconv"
 )
-func checkErr(e error){
-	if (e != nil) {
+
+func checkErr(e error) {
+	if e != nil {
 		fmt.Println("POOP!")
 		os.Exit(1)
 	}
@@ -30,10 +31,10 @@ func onlyDirectories(potential_files []os.FileInfo) (out_ls []os.FileInfo) {
 
 // Extend "records" matrix to have rows until time "desired_time"
 // Return: Extended version of record
-func extendRecordsToTime(records [][]string, desired_time int, recordCols int) ([][]string)  {
+func extendRecordsToTime(records [][]string, desired_time int, recordCols int) [][]string {
 	lenr := len(records)
 	// records[1] stores cycle [1], as records[0] is column names
-	for j := lenr; j < desired_time + 1; j++ {
+	for j := lenr; j < desired_time+1; j++ {
 		records = append(records, make([]string, recordCols))
 		records[j][0] = strconv.Itoa(j)
 		for k := 1; k < recordCols; k++ {
@@ -87,14 +88,14 @@ func composeAllNamed(desired_report_fname string) {
 				experiment_records, err := this_reader.ReadAll()
 				checkErr(err)
 				// Add the name of this new column to records[0]
-				records[0] = append(records[0], fengine.Name() + trial.Name())
+				records[0] = append(records[0], fengine.Name()+trial.Name())
 
 				for _, row := range experiment_records {
 					// row[0] is time, on the x-axis; row[1] is value, on the y-axis
 					time_now, err := strconv.Atoi(row[0])
 					checkErr(err)
 					//If this test went longer than all of the others, so far
-					if(len(records) < time_now + 1) {
+					if len(records) < time_now+1 {
 						records = extendRecordsToTime(records, time_now, num_record_columns)
 					}
 					records[time_now][j+1] = row[1]
@@ -109,11 +110,10 @@ func composeAllNamed(desired_report_fname string) {
 	}
 }
 
-func main(){
+func main() {
 	composeAllNamed("coverage-graph.csv")
 	composeAllNamed("corpus-size-graph.csv")
 	composeAllNamed("corpus-elems-graph.csv")
 	// createIFramesFor("setOfFrames.html")
 	// <iframe width="960" height="500" src="benchmarkN/report.html" frameborder="0"></iframe>
 }
-

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -135,16 +135,17 @@ func appendFastestTrial(meta_records [][]string, records [][]string) [][]string 
 func handleBmark(bmark os.FileInfo, records_path string, desired_report_fname string) {
 	bmark_records := [][]string{{"time"}}
 
-	potential_fengines, err := ioutil.ReadDir(path.Join(records_path, bmark.Name()))
+	bmark_path = path.Join(records_path, bmark.Name())
+	potential_fengines, err := ioutil.ReadDir(bmark_path)
 	checkErr(err)
 	// narrow potential_fengines to fengines so the indices of `range fengines` are useful
 	fengines := onlyDirectories(potential_fengines)
 
 	for _, fengine := range fengines {
-		fengine_records := handleFengine(fengine, path.Join(records_path, bmark.Name()), desired_report_fname)
+		fengine_records := handleFengine(fengine, bmark_path, desired_report_fname)
 		bmark_records = appendFastestTrial(bmark_records, fengine_records)
 	}
-	this_bm_file, err := os.Create(path.Join(records_path, bmark.Name(), desired_report_fname))
+	this_bm_file, err := os.Create(path.Join(bmark_path, desired_report_fname))
 	checkErr(err)
 	this_bm_writer := csv.NewWriter(this_bm_file)
 	this_bm_writer.WriteAll(bmark_records)

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -32,6 +32,7 @@ func onlyDirectories(potential_files []os.FileInfo) (out_ls []os.FileInfo) {
 // Return: Extended version of record
 func extendRecordsToTime(records [][]string, desired_time int, recordCols int) ([][]string)  {
 	lenr := len(records)
+	// records[1] stores cycle [1], as records[0] is column names
 	for j := lenr; j < desired_time + 1; j++ {
 		records = append(records, make([]string, recordCols))
 		records[j][0] = strconv.Itoa(j)
@@ -79,11 +80,14 @@ func composeAllNamed(desired_report_fname string) {
 				defer this_file.Close()
 				this_reader := csv.NewReader(this_file)
 
+				// Read whole CSV to an array
 				experiment_records, err := this_reader.ReadAll()
 				checkErr(err)
+				// Add the name of this new column to records[0]
 				records[0] = append(records[0], fengine.Name() + trial.Name())
 
 				for _, row := range experiment_records {
+					// row[0] is time, on the x-axis; row[1] is value, on the y-axis
 					time_now, err := strconv.Atoi(row[0])
 					checkErr(err)
 					//If this test went longer than all of the others, so far
@@ -92,12 +96,13 @@ func composeAllNamed(desired_report_fname string) {
 					}
 					records[time_now][j+1] = row[1]
 				}
-				this_fe_writer.WriteAll(records)
 			}
-			// TODO: create comparison between fengines, having already composed trials
-			// Do this by identifying the max (or potentially median) performing trial
-			// For each fengine, and putting them all into a CSV which can be graphed
+			this_fe_writer.WriteAll(records)
+			// Potentially put this fengine into a broader comparison CSV
 		}
+		// TODO: create comparison between fengines, having already composed trials
+		// Do this by identifying the max (or potentially median) performing trial
+		// For each fengine, and putting them all into a CSV which can be graphed
 	}
 }
 
@@ -108,6 +113,4 @@ func main(){
 	// createIFramesFor("setOfFrames.html")
 	// <iframe width="960" height="500" src="benchmarkN/report.html" frameborder="0"></iframe>
 }
-
-
 

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -64,8 +64,6 @@ func handleTrialCSV(this_reader *csv.Reader, records [][]string, column_name str
 }
 
 func handleFengine(fengine os.FileInfo, current_path string, desired_report_fname string) {
-
-
 	// Create matrix, to eventually become a CSV
 	records := [][]string{{"time"}}
 
@@ -87,9 +85,9 @@ func handleFengine(fengine os.FileInfo, current_path string, desired_report_fnam
 
 	this_fe_file, err := os.Create(path.Join(current_path, fengine.Name(), desired_report_fname))
 	checkErr(err)
-	defer this_fe_file.Close()
 	this_fe_writer := csv.NewWriter(this_fe_file)
 	this_fe_writer.WriteAll(records)
+	this_fe_file.Close()
 	// Potentially put this fengine into a broader comparison CSV
 }
 

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -13,13 +13,12 @@ import (
 
 func checkErr(e error) {
 	if e != nil {
-		fmt.Println("POOP!")
+		fmt.Println("Poop! Error encountered:", e)
 		os.Exit(1)
 	}
 }
 
-// Removes non-directory elements of any []os.FileInfo (a helper function, for convenience)
-// Makes use of idiomatic Golang return: out_ls is declared and returned implicitly
+// Removes non-directory elements of any []os.FileInfo
 func onlyDirectories(potential_files []os.FileInfo) (out_ls []os.FileInfo) {
 	for _, fd := range potential_files {
 		if fd.IsDir() {
@@ -31,15 +30,12 @@ func onlyDirectories(potential_files []os.FileInfo) (out_ls []os.FileInfo) {
 
 // Extend "records" matrix to have rows until time "desired_time"
 // Return: Extended version of record
-func extendRecordsToTime(records [][]string, desired_time int, recordCols int) [][]string {
+func extendRecordsToTime(records [][]string, desired_time int, record_cols int) [][]string {
 	lenr := len(records)
 	// records[1] stores cycle [1], as records[0] is column names
 	for j := lenr; j < desired_time+1; j++ {
-		records = append(records, make([]string, recordCols))
+		records = append(records, make([]string, record_cols))
 		records[j][0] = strconv.Itoa(j)
-		for k := 1; k < recordCols; k++ {
-			records[j][k] = ""
-		}
 	}
 	return records
 }
@@ -90,14 +86,16 @@ func composeAllNamed(desired_report_fname string) {
 				// Add the name of this new column to records[0]
 				records[0] = append(records[0], fengine.Name()+trial.Name())
 
+				final_time, err := strconv.Atoi(experiment_records[len(experiment_records)-1][0])
+				checkErr(err)
+				//If this test went longer than all of the others, so far
+				if len(records) < final_time+1 {
+					records = extendRecordsToTime(records, final_time, num_record_columns)
+				}
 				for _, row := range experiment_records {
 					// row[0] is time, on the x-axis; row[1] is value, on the y-axis
 					time_now, err := strconv.Atoi(row[0])
 					checkErr(err)
-					//If this test went longer than all of the others, so far
-					if len(records) < time_now+1 {
-						records = extendRecordsToTime(records, time_now, num_record_columns)
-					}
 					records[time_now][j+1] = row[1]
 				}
 			}

--- a/engine-comparison/report-gen/generate-report.go
+++ b/engine-comparison/report-gen/generate-report.go
@@ -79,7 +79,7 @@ func handleFengine(fengine os.FileInfo, current_path string, desired_report_fnam
 		checkErr(err)
 		this_reader := csv.NewReader(this_file)
 
-		records = handleTrialCSV(this_reader, records, fengine.Name() + trial.Name(), num_record_columns, j)
+		records = handleTrialCSV(this_reader, records, fengine.Name()+trial.Name(), num_record_columns, j)
 		this_file.Close()
 	}
 

--- a/engine-comparison/report-gen/setOfCharts.html
+++ b/engine-comparison/report-gen/setOfCharts.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Page Title</title>
+<head>
+  <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+  <script>
+    // Based on examples at https://developers.google.com/chart/interactive/docs/gallery/linechart
+    google.charts.load('current', {'packages':['corechart']});
+    google.charts.setOnLoadCallback(drawChart);
+
+    function graphFromText(filename, inputText) {
+      var csvMatrix = inputText.split("\n").map(function(row){return row.split(",");});
+
+      csvMatrix = csvMatrix.slice(0,csvMatrix.length - 1);
+      csvMatrix.forEach( function(row, index) {
+        if (index != 0) {
+          csvMatrix[index] = row.map(function(num)  { return parseInt(num); });
+        }
+      });
+      var data = google.visualization.arrayToDataTable(csvMatrix);
+      var chart = new google.visualization.LineChart(document.getElementById('curve_chart'));
+      var options = {
+        title: filename,
+        curveType: 'function',
+        legend: { position: 'bottom' }
+      };
+      // defaults to false:
+      // data.setColumnProperty(colIndex, 'interpolateNulls', true);
+      chart.draw(data, options);
+    }
+
+    // Totall generic AJAX: fetch string from file
+    function generateGraph(filename, handleText) {
+      var xhr = new XMLHttpRequest();
+      xhr.onreadystatechange = function() {
+        if ((xhr.readyState == 4) && (xhr.status == 200)) {
+          graphFromText(filename, xhr.responseText);
+        }
+      }
+      xhr.open("GET", filename);
+      xhr.send();
+    }
+
+    function drawChart() {
+      generateGraph("coverage-graph.csv", graphFromText);
+      generateGraph("corpus-size-graph.csv", graphFromText);
+      generateGraph("corpus-elems-graph.csv", graphFromText);
+    }
+
+  </script>
+</head>
+<body>
+  <div id="curve_chart" style="width: 900px; height: 500px"></div>
+</body>
+

--- a/engine-comparison/report-gen/setOfCharts.html
+++ b/engine-comparison/report-gen/setOfCharts.html
@@ -50,8 +50,8 @@
   </script>
 </head>
 <body>
-  <div id="curve_chart_1" style="width: 900px; height: 500px"></div>
-  <div id="curve_chart_2" style="width: 900px; height: 500px"></div>
-  <div id="curve_chart_3" style="width: 900px; height: 500px"></div>
+  <div id="curve_chart_1" style="width: 600px; height: 270px"></div>
+  <div id="curve_chart_2" style="width: 600px; height: 270px"></div>
+  <div id="curve_chart_3" style="width: 600px; height: 270px"></div>
 </body>
 

--- a/engine-comparison/report-gen/setOfCharts.html
+++ b/engine-comparison/report-gen/setOfCharts.html
@@ -8,7 +8,7 @@
     google.charts.load('current', {'packages':['corechart']});
     google.charts.setOnLoadCallback(drawChart);
 
-    function graphFromText(filename, inputText) {
+    function graphFromText(filename, inputText, divName) {
       var csvMatrix = inputText.split("\n").map(function(row){return row.split(",");});
 
       csvMatrix = csvMatrix.slice(0,csvMatrix.length - 1);
@@ -18,7 +18,7 @@
         }
       });
       var data = google.visualization.arrayToDataTable(csvMatrix);
-      var chart = new google.visualization.LineChart(document.getElementById('curve_chart'));
+      var chart = new google.visualization.LineChart(document.getElementById(divName));
       var options = {
         title: filename,
         curveType: 'function',
@@ -30,11 +30,11 @@
     }
 
     // Totall generic AJAX: fetch string from file
-    function generateGraph(filename, handleText) {
+    function generateGraph(filename, handleText, divName) {
       var xhr = new XMLHttpRequest();
       xhr.onreadystatechange = function() {
         if ((xhr.readyState == 4) && (xhr.status == 200)) {
-          graphFromText(filename, xhr.responseText);
+          graphFromText(filename, xhr.responseText, divName);
         }
       }
       xhr.open("GET", filename);
@@ -42,14 +42,16 @@
     }
 
     function drawChart() {
-      generateGraph("coverage-graph.csv", graphFromText);
-      generateGraph("corpus-size-graph.csv", graphFromText);
-      generateGraph("corpus-elems-graph.csv", graphFromText);
+      generateGraph("coverage-graph.csv", graphFromText, "curve_chart_1");
+      generateGraph("corpus-size-graph.csv", graphFromText, "curve_chart_2");
+      generateGraph("corpus-elems-graph.csv", graphFromText, "curve_chart_3");
     }
 
   </script>
 </head>
 <body>
-  <div id="curve_chart" style="width: 900px; height: 500px"></div>
+  <div id="curve_chart_1" style="width: 900px; height: 500px"></div>
+  <div id="curve_chart_2" style="width: 900px; height: 500px"></div>
+  <div id="curve_chart_3" style="width: 900px; height: 500px"></div>
 </body>
 


### PR DESCRIPTION
This is a WIP for how I propose to do report generation. It is missing some pieces, but fit for broad critique/input as I continue working on it.

The first step is complete here: putting CSVs for each trial into a single CSV for a given `benchmark/fengine`. 

Some work which remains is to put all fengine CSVs into a single CSV for each `benchmark/` folder. This could be the maximum trial from within each fengine CSV, or the median trial, or just all of them.

There also remains copying `setOfCharts.html` into the appropriate directories, as well as the creation of a `main.html` which would simply `iframe` all respective copies of `setOfCharts.html`. I believe `main.html` could be generated in golang, as it would be a series of very similar/formulaic lines of code. 