### PR TITLE
Rsync speedup.

### DIFF
--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -253,6 +253,15 @@ measure_coverage() {
     # Save corpus for comparison next cycle
     rm -rf "${prev_corpus_dir}"
     mv "${corpus_dir}" "${prev_corpus_dir}"
+
+    # Move this corpus archive to the processed folder so that rsync doesn't
+    # need to check it anymore.
+    local bmark_trial="${benchmark}-${fengine_name}/trial-${LATEST_TRIAL}"
+    local src_archive="${GSUTIL_BUCKET}/experiment-folders/${bmark_trial}"
+    src_archive="${src_archive}/corpus/corpus-archive-${this_cycle}.tar.gz"
+    local dst_archive="${GSUTIL_BUCKET}/processed-folders/${bmark_trial}"
+    dst_archive="${dst_archive}/corpus-archive-${this_cycle}.tar.gz"
+    gsutil mv "${src_archive}" "${dst_archive}"
   fi
 
   # Finish generating human readable report
@@ -339,6 +348,8 @@ main() {
 
   mkdir -p "${WORK}/experiment-folders"
   mkdir -p "${WORK}/measurement-folders"
+
+  gsutil rm -r "${GSUTIL_BUCKET}/processed-folders"
 
   # wait_period defines how frequently the dispatcher generates new reports for
   # every benchmark with every fengine. For a large number of runner VMs,

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -205,6 +205,10 @@ measure_coverage() {
   # First, check if the runner documented that it skipped any cycles
   local this_cycle=$((LATEST_CYCLE + 1))
   while grep "^${this_cycle}$" "${experiment_dir}/results/skipped-cycles"; do
+    # Record empty stats for proper data aggregation later.
+    echo "${this_cycle}" >> "${report_dir}/coverage-graph.csv"
+    echo "${this_cycle}" >> "${report_dir}/corpus-size-graph.csv"
+    echo "${this_cycle}" >> "${report_dir}/corpus-elems-graph.csv"
     this_cycle=$((this_cycle + 1))
   done
 

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -13,7 +13,7 @@
 # conditions.
 p_gsutil() {
   local state_dir="/tmp/gsutil.${BASHPID}"
-  gsutil -o "GSUtil:state_dir=${state_dir}" "$@"
+  gsutil -m -o "GSUtil:state_dir=${state_dir}" "$@"
   rm -rf "${state_dir}"
 }
 
@@ -21,7 +21,7 @@ p_gsutil() {
 rsync_delete() {
   local src=$1
   local dst=$2
-  p_gsutil -m rsync -rd "${src}" "${dst}"
+  p_gsutil rsync -rd "${src}" "${dst}"
 }
 
 # Run the specified command in a shell with no environment variables set.
@@ -273,7 +273,7 @@ measure_coverage() {
     src_archive="${src_archive}/corpus/corpus-archive-${this_cycle}.tar.gz"
     local dst_archive="${GSUTIL_BUCKET}/processed-folders/${bmark_trial}"
     dst_archive="${dst_archive}/corpus-archive-${this_cycle}.tar.gz"
-    p_gsutil -m mv "${src_archive}" "${dst_archive}"
+    p_gsutil mv "${src_archive}" "${dst_archive}"
   fi
 
   # Finish generating human readable report
@@ -312,7 +312,7 @@ main() {
   readonly BENCHMARKS
 
   # Reset google cloud results before doing experiments
-  gsutil -m rm -r "${GSUTIL_BUCKET}/experiment-folders" \
+  p_gsutil rm -r "${GSUTIL_BUCKET}/experiment-folders" \
     "${GSUTIL_BUCKET}/reports"
 
   # Outermost loops
@@ -361,7 +361,7 @@ main() {
   mkdir -p "${WORK}/experiment-folders"
   mkdir -p "${WORK}/measurement-folders"
 
-  gsutil -m rm -r "${GSUTIL_BUCKET}/processed-folders"
+  p_gsutil rm -r "${GSUTIL_BUCKET}/processed-folders"
 
   # wait_period defines how frequently the dispatcher generates new reports for
   # every benchmark with every fengine. For a large number of runner VMs,

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -43,7 +43,6 @@ conduct_experiment() {
     # Snapshot
     cp -r corpus corpus-copy
 
-    echo "VM_SECONDS=${SECONDS}" > results/seconds-${cycle}
     if diff <(ls corpus-copy) <(ls last-corpus); then
       # Corpus is unchanged; avoid rsyncing it.
       echo "${cycle}" >> results/unchanged-cycles
@@ -56,7 +55,6 @@ conduct_experiment() {
     # Done with snapshot
     rm -r last-corpus
     mv corpus-copy last-corpus
-    rm "results/seconds-${cycle}"
     rm "corpus-archives/corpus-archive-${cycle}.tar.gz"
 
     cycle=$((cycle + 1))

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -68,7 +68,7 @@ conduct_experiment() {
   done
 
   # Sync final fuzz log
-  cp fuzz-0.log crash* leak* timeout* results/
+  cp fuzz-0.log crash* leak* timeout* oom* results/
   rsync_no_delete results "${sync_dir}/results"
 }
 

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -68,7 +68,7 @@ conduct_experiment() {
   done
 
   # Sync final fuzz log
-  cp fuzz-0.log crash* leak* timeout* oom* results/
+  mv fuzz-0.log crash* leak* timeout* oom* results/
   rsync_no_delete results "${sync_dir}/results"
 }
 


### PR DESCRIPTION
Avoid rsyncing unnecessary files.  For long-running experiments, rsync time goes from ~20 seconds to 1 second.

With this PR the dispatcher is able to keep the pipeline of unanalyzed corpora essentially empty, even with two fuzzing engines and all benchmarks enabled.

A couple bug fixes are also included.

Fixes #43.