### PR TITLE
Added $JOBS variable to all make -j commands

### DIFF
--- a/boringssl-2016-02-12/build.sh
+++ b/boringssl-2016-02-12/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS="$CFLAGS -Wno-deprecated-declarations" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=main" && make -j)
+  (cd BUILD && cmake -DBUILD_SHARED_LIBS=OFF -DCMAKE_C_COMPILER="$CC" -DCMAKE_C_FLAGS="$CFLAGS -Wno-deprecated-declarations" -DCMAKE_CXX_COMPILER="$CXX" -DCMAKE_CXX_FLAGS="$CXXFLAGS -Wno-error=main" && make -j $JOBS)
 }
 
 get_git_revision https://github.com/google/boringssl.git  894a47df2423f0d2b6be57e6d90f2bea88213382 SRC

--- a/c-ares-CVE-2016-5180/build.sh
+++ b/c-ares-CVE-2016-5180/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./buildconf && ./configure && make -j )
+  (cd BUILD && ./buildconf && ./configure && make -j $JOBS)
 }
 get_git_revision https://github.com/c-ares/c-ares.git 51fbb479f7948fca2ace3ff34a15ff27e796afdd SRC
 build_lib

--- a/libpng-1.2.56/build.sh
+++ b/libpng-1.2.56/build.sh
@@ -10,7 +10,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf libpng-1.2.56 BUILD
-  (cd BUILD && ./configure &&  make -j)
+  (cd BUILD && ./configure &&  make -j $JOBS)
 }
 
 build_lib || exit 1

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -9,7 +9,7 @@ CXXFLAGS="${CXXFLAGS} -std=gnu++98"
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && make clean &&  make -j)
+  (cd BUILD && make clean &&  make -j $JOBS)
 }
 
 get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a77b6ac335de SRC


### PR DESCRIPTION
Some of the `make -j` commands were missing the `$JOBS` variable. Added it to make it consistent across all targets.