### PR TITLE
libarchive: Add -llz4 -llzo2

### DIFF
--- a/libarchive-2017-01-04/build.sh
+++ b/libarchive-2017-01-04/build.sh
@@ -19,4 +19,4 @@ if [[ $FUZZING_ENGINE == "hooks" ]]; then
   LIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE -fsanitize=address"
 fi
 set -x
-$CXX $CXXFLAGS -std=c++11 $SCRIPT_DIR/libarchive_fuzzer.cc -I BUILD/libarchive BUILD/.libs/libarchive.a $LIB_FUZZING_ENGINE -lz  -lbz2 -lxml2 -lcrypto -lssl -llzma -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 $SCRIPT_DIR/libarchive_fuzzer.cc -I BUILD/libarchive BUILD/.libs/libarchive.a $LIB_FUZZING_ENGINE -lz  -lbz2 -lxml2 -lcrypto -lssl -llzma -llz4 -llzo2 -o $EXECUTABLE_NAME_BASE


### PR DESCRIPTION
When building `libarchive`, I needed to link libraries LZ4 and LZO. If not, I would get undefined references to functions such as `LZ4_decompress_safe` and  `lzo1x_decompress_safe` from the final fuzz target.

Either these libraries need to be linked in (using the patch in this PR), or else `libarchive` needs to be configured to disable these formats.