### PR TITLE
Add honggfuzz to fuzzing engines

### DIFF
--- a/engine-comparison/dispatcher-image/Dockerfile
+++ b/engine-comparison/dispatcher-image/Dockerfile
@@ -8,12 +8,12 @@ RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main" >> \
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN apt-get update -y && apt-get install -y git subversion wget cmake automake \
-    google-cloud-sdk clang-7 libarchive-dev libfreetype6-dev libglib2.0-dev \
+    google-cloud-sdk clang-9 libarchive-dev libfreetype6-dev libglib2.0-dev \
     libcairo2-dev openssl libtool ragel golang libxml2-dev libssl-dev nasm \
     python-dev libgcrypt20-dev libgss-dev liblzma-dev libdbus-1-dev \
-    libboost-dev autoconf-archive libbz2-dev
-RUN ln -s /usr/bin/clang-7 /usr/bin/clang
-RUN ln -s /usr/bin/clang++-7 /usr/bin/clang++
+    libboost-dev autoconf-archive libbz2-dev libbfd-dev libunwind-dev
+RUN ln -s /usr/bin/clang-9 /usr/bin/clang
+RUN ln -s /usr/bin/clang++-9 /usr/bin/clang++
 
 # Create directory, and set it as the working directory "."
 WORKDIR /work

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -132,6 +132,16 @@ download_engine() {
 
   . "${fengine_config}"
   case "${FUZZING_ENGINE}" in
+    honggfuzz)
+      if [[ ! -f "${HONGGFUZZ_SRC}/" ]]; then
+        echo "Checking out honggfuzz"
+        git clone https://github.com/google/honggfuzz.git "${HONGGFUZZ_SRC}"
+        # Unset CC, CXX and CFLAGS so we don't try to compile honggfuzz
+        # with honggfuzz-clang (which common.sh sets CC to)
+        echo "Building honggfuzz"
+        (cd "${HONGGFUZZ_SRC}" && env -u CC -u CXX -u CFLAGS -u CXXFLAGS make)
+      fi
+      ;;
     libfuzzer)
       if [[ ! -d "${LIBFUZZER_SRC}/standalone" ]]; then
         echo "Checking out libFuzzer"
@@ -211,6 +221,7 @@ package_benchmark_fuzzer() {
     cp "${building_dir}"/*.dict "${send_dir}"
 
   [[ "${FUZZING_ENGINE}" == "afl" ]] && cp "${AFL_SRC}/afl-fuzz" "${send_dir}"
+  [[ "${FUZZING_ENGINE}" == "honggfuzz" ]] && cp "${HONGGFUZZ_SRC}/honggfuzz" "${send_dir}"
 }
 
 # Starts a runner VM

--- a/engine-comparison/dispatcher.sh
+++ b/engine-comparison/dispatcher.sh
@@ -133,7 +133,7 @@ download_engine() {
   . "${fengine_config}"
   case "${FUZZING_ENGINE}" in
     honggfuzz)
-      if [[ ! -f "${HONGGFUZZ_SRC}/" ]]; then
+      if [[ ! -d "${HONGGFUZZ_SRC}/" ]]; then
         echo "Checking out honggfuzz"
         git clone https://github.com/google/honggfuzz.git "${HONGGFUZZ_SRC}"
         # Unset CC, CXX and CFLAGS so we don't try to compile honggfuzz

--- a/engine-comparison/runner-image/Dockerfile
+++ b/engine-comparison/runner-image/Dockerfile
@@ -4,7 +4,7 @@ RUN echo "deb http://packages.cloud.google.com/apt cloud-sdk-xenial main" >> \
     /etc/apt/sources.list
 RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN apt-get update -y && apt-get install -y google-cloud-sdk libarchive13 \
-    libglib2.0-0 libgss3
+    libglib2.0-0 libgss3 libbfd-dev libunwind-dev
 
 # Create directory, and set it as the working directory "."
 WORKDIR /work

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -145,6 +145,16 @@ main() {
       exec_cmd="${exec_cmd} -x ${dict_path}@9"
     fi
     exec_cmd="${exec_cmd} -m none -- ${binary}"
+  elif [[ "${FUZZING_ENGINE}" == "honggfuzz" ]]; then
+    chmod 750 honggfuzz
+
+    local exec_cmd="./honggfuzz ${BINARY_RUNTIME_OPTIONS} --sanitizers --persistent --threads 1"
+    local exec_cmd="${exec_cmd} --input seeds --crashdir crashes --covdir_all corpus"
+    if ls ./*.dict; then
+      local dict_path="$(find . -maxdepth 1 -name "*.dict" | head -n 1)"
+      exec_cmd="${exec_cmd} --dict ${dict_path}"
+    fi
+    exec_cmd="${exec_cmd} -- ${binary}"
   elif [[ "${FUZZING_ENGINE}" == "libfuzzer" || \
     "${FUZZING_ENGINE}" == "fsanitize_fuzzer" ]]; then
     export ASAN_OPTIONS="symbolize=0"

--- a/engine-comparison/runner.sh
+++ b/engine-comparison/runner.sh
@@ -62,7 +62,7 @@ conduct_experiment() {
     # Delete most crashes and logs to save disk space.
     find . -name "fuzz-[1-9][0-9]*.log" -delete
     if [[ -z "$(ls -A crashes)" ]]; then
-      mv corpus/crashes/* corpus/hangs/* crashes/
+      mv corpus/crashes/* corpus/hangs/* honggfuzz-crashes/* crashes/
       mv crash-* leak* timeout* oom* crashes/
       if [[ -n "$(ls -A crashes)" ]]; then
         cp fuzz-0.log crashes/* results/
@@ -148,8 +148,11 @@ main() {
   elif [[ "${FUZZING_ENGINE}" == "honggfuzz" ]]; then
     chmod 750 honggfuzz
 
-    local exec_cmd="./honggfuzz ${BINARY_RUNTIME_OPTIONS} --sanitizers --persistent --threads 1"
-    local exec_cmd="${exec_cmd} --input seeds --crashdir crashes --covdir_all corpus"
+    # Honggfuzz requires the seeds directory to exist
+    [[ ! -d seeds ]] && mkdir seeds
+
+    local exec_cmd="./honggfuzz ${BINARY_RUNTIME_OPTIONS} --sanitizers --persistent --threads ${JOBS}"
+    local exec_cmd="${exec_cmd} --input seeds --crashdir honggfuzz-crashes --covdir_all corpus"
     if ls ./*.dict; then
       local dict_path="$(find . -maxdepth 1 -name "*.dict" | head -n 1)"
       exec_cmd="${exec_cmd} --dict ${dict_path}"


### PR DESCRIPTION
This allows benchmarks to be built with honggfuzz as long as you point `HONGGFUZZ_SRC` to the git repo with `make` ran in it. 

Additionally, this also integrates honggfuzz into the AB-comparison engine. The docker images for the runner and dispatcher will need to be rebuilt and pushed up as they now include honggfuzz's runtime dependencies.