### PR TITLE
Fix usage example in engine-comparison README

### DIFF
--- a/engine-comparison/README.md
+++ b/engine-comparison/README.md
@@ -120,8 +120,8 @@ corresponding script invocation would be:
 
 ```shell
 ${FTS}/engine-comparison/begin-experiment.sh \
-  ./param/afl-vs-lf.cfg \
   boringssl-2016-02-12,freetype2-2017,guetzli-2017-3-30 \
+  ./param/afl-vs-lf.cfg \
   ./config/afl ./config/libfuzzer
 ```
 


### PR DESCRIPTION
The arguments were flipped, it's benchmarks and then the experiment-config as shown in the [usage](https://github.com/google/fuzzer-test-suite/tree/master/engine-comparison#usage) section and the code: https://github.com/google/fuzzer-test-suite/blob/8cf9edcada50f654c973ff3263ad823650e951a6/engine-comparison/begin-experiment.sh#L22