### PR TITLE
Missing -lpthread from proj4 target

### DIFF
--- a/proj4-2017-08-14/build.sh
+++ b/proj4-2017-08-14/build.sh
@@ -23,4 +23,4 @@ if [[ $FUZZING_ENGINE == "hooks" ]]; then
   # Link ASan runtime so we can hook memcmp et al.
   LIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE -fsanitize=address"
 fi
-$CXX $CXXFLAGS -std=c++11 -I BUILD/src BUILD/test/fuzzers/standard_fuzzer.cpp BUILD/src/.libs/libproj.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -std=c++11 -I BUILD/src BUILD/test/fuzzers/standard_fuzzer.cpp BUILD/src/.libs/libproj.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE -lpthread


### PR DESCRIPTION
I think that it is just luck that the proj4 target builds: for some reason having the `-fsanitize-coverage=trace-pc-guard` flag makes it build. Without this flag I get the following error:

```
pj_mutex.c:126: error: undefined reference to 'pthread_mutexattr_init'
pj_mutex.c:128: error: undefined reference to 'pthread_mutexattr_settype'
clang-7: error: linker command failed with exit code 1 (use -v to see invocation)
```

Looking through the proj4 code (in particular, `test/fuzzers/build_google_oss_fuzzers.sh`), `-lpthread` is definitely required.