### PR TITLE
build: disable all shared libs

### DIFF
--- a/boringssl-2016-02-12/build.sh
+++ b/boringssl-2016-02-12/build.sh
@@ -24,4 +24,4 @@ if [[ $FUZZING_ENGINE == "hooks" ]]; then
   LIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE -fsanitize=address"
 fi
 set -x
-$CXX $CXXFLAGS -I BUILD/include BUILD/fuzz/privkey.cc ./BUILD/ssl/libssl.a ./BUILD/crypto/libcrypto.a $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE
+$CXX $CXXFLAGS -I BUILD/include BUILD/fuzz/privkey.cc ./BUILD/ssl/libssl.a ./BUILD/crypto/libcrypto.a -lpthread $LIB_FUZZING_ENGINE -o $EXECUTABLE_NAME_BASE

--- a/c-ares-CVE-2016-5180/build.sh
+++ b/c-ares-CVE-2016-5180/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./buildconf && ./configure && make -j $JOBS)
+  (cd BUILD && ./buildconf && ./configure --disable-shared && make -j $JOBS)
 }
 get_git_revision https://github.com/c-ares/c-ares.git 51fbb479f7948fca2ace3ff34a15ff27e796afdd SRC
 build_lib

--- a/common.sh
+++ b/common.sh
@@ -91,6 +91,7 @@ build_coverage () {
   STANDALONE_TARGET=1
   $CC -O2 -c $LIBFUZZER_SRC/standalone/StandaloneFuzzTargetMain.c
   ar rc $LIB_FUZZING_ENGINE StandaloneFuzzTargetMain.o
+  rm *.o
 }
 
 # Build with user-defined main and hooks.

--- a/freetype2-2017/build.sh
+++ b/freetype2-2017/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh && ./configure --with-harfbuzz=no --with-bzip2=no --with-png=no && make clean && make all -j $JOBS)
+  (cd BUILD && ./autogen.sh && ./configure --disable-shared --with-harfbuzz=no --with-bzip2=no --with-png=no && make clean && make all -j $JOBS)
 }
 
 get_git_revision git://git.sv.nongnu.org/freetype/freetype2.git cd02d359a6d0455e9d16b87bf9665961c4699538 SRC

--- a/lcms-2017-03-21/build.sh
+++ b/lcms-2017-03-21/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh && ./configure && make -j $JOBS)
+  (cd BUILD && ./autogen.sh && ./configure --disable-shared && make -j $JOBS)
 }
 
 get_git_revision https://github.com/mm2/Little-CMS.git f9d75ccef0b54c9f4167d95088d4727985133c52 SRC

--- a/libarchive-2017-01-04/build.sh
+++ b/libarchive-2017-01-04/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD/build && ./autogen.sh && cd .. && ./configure --without-nettle && make -j $JOBS)
+  (cd BUILD/build && ./autogen.sh && cd .. && ./configure --disable-shared --without-nettle && make -j $JOBS)
 }
 
 get_git_revision https://github.com/libarchive/libarchive.git 51d7afd3644fdad725dd8faa7606b864fd125f88 SRC

--- a/libjpeg-turbo-07-2017/build.sh
+++ b/libjpeg-turbo-07-2017/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && autoreconf -fiv && ./configure && make -j $JOBS)
+  (cd BUILD && autoreconf -fiv && ./configure --disable-shared && make -j $JOBS)
 }
 
 get_git_revision https://github.com/libjpeg-turbo/libjpeg-turbo.git b0971e47d76fdb81270e93bbf11ff5558073350d SRC

--- a/libpng-1.2.56/build.sh
+++ b/libpng-1.2.56/build.sh
@@ -10,7 +10,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf libpng-1.2.56 BUILD
-  (cd BUILD && ./configure &&  make -j $JOBS)
+  (cd BUILD && ./configure --disable-shared &&  make -j $JOBS)
 }
 
 build_lib || exit 1

--- a/libxml2-v2.9.2/build.sh
+++ b/libxml2-v2.9.2/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh && CCLD="$CXX $CXXFLAGS" ./configure && make -j $JOBS)
+  (cd BUILD && ./autogen.sh && CCLD="$CXX $CXXFLAGS" ./configure --disable-shared && make -j $JOBS)
 }
 
 get_git_tag https://gitlab.gnome.org/GNOME/libxml2.git v2.9.2 SRC

--- a/openthread-2018-02-27/build.sh
+++ b/openthread-2018-02-27/build.sh
@@ -15,6 +15,7 @@ build_lib() {
     LIB_FUZZING_ENGINE="$LIB_FUZZING_ENGINE -fsanitize=address"
   fi
   (cd BUILD && ./bootstrap && ./configure \
+    --disable-shared                    \
     --enable-fuzz-targets               \
     --enable-application-coap           \
     --enable-border-router              \

--- a/pcre2-10.00/build.sh
+++ b/pcre2-10.00/build.sh
@@ -9,7 +9,7 @@ build_lib() {
   cp -rf SRC BUILD
   (cd BUILD &&
     ./autogen.sh &&
-     CCLD="$CXX $CXXFLAGS" ./configure --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-recursion=1000 &&
+     CCLD="$CXX $CXXFLAGS" ./configure --disable-shared --enable-never-backslash-C --with-match-limit=1000 --with-match-limit-recursion=1000 &&
      make -j
   )
 }

--- a/proj4-2017-08-14/build.sh
+++ b/proj4-2017-08-14/build.sh
@@ -7,7 +7,7 @@
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && ./autogen.sh &&  ./configure  &&  make clean  && make -j $JOBS )
+  (cd BUILD && ./autogen.sh &&  ./configure --disable-shared &&  make clean  && make -j $JOBS )
 }
 
 get_git_revision https://github.com/OSGeo/proj.4.git d00501750b210a73f9fb107ac97a683d4e3d8e7a SRC

--- a/re2-2014-12-09/build.sh
+++ b/re2-2014-12-09/build.sh
@@ -9,7 +9,7 @@ CXXFLAGS="${CXXFLAGS} -std=gnu++98"
 build_lib() {
   rm -rf BUILD
   cp -rf SRC BUILD
-  (cd BUILD && make clean &&  make -j $JOBS)
+  (cd BUILD && make clean &&  make -j $JOBS obj/libre2.a)
 }
 
 get_git_revision https://github.com/google/re2.git 499ef7eff7455ce9c9fae86111d4a77b6ac335de SRC


### PR DESCRIPTION
Disable shared libs for the other targets. Never used and simplifies builds.