### PR TITLE
Revert "Download libpng from vorboss mirror."

### DIFF
--- a/libpng-1.2.56/build.sh
+++ b/libpng-1.2.56/build.sh
@@ -4,7 +4,7 @@
 . $(dirname $0)/../custom-build.sh $1 $2
 . $(dirname $0)/../common.sh
 
-[ ! -e libpng-1.2.56.tar.gz ] && wget https://vorboss.dl.sourceforge.net/project/libpng/libpng12/older-releases/1.2.56/libpng-1.2.56.tar.gz
+[ ! -e libpng-1.2.56.tar.gz ] && wget https://downloads.sourceforge.net/project/libpng/libpng12/older-releases/1.2.56/libpng-1.2.56.tar.gz
 [ ! -e libpng-1.2.56 ] && tar xf libpng-1.2.56.tar.gz
 
 build_lib() {


### PR DESCRIPTION
This reverts commit e0a0b361f8898c4934cc400ea90fcca6816c803c.
Sourceforge is back up, and the vorboss mirror is currently offline.