### PR TITLE
Added LIBFUZZER_FLAGS variable to test-libfuzzer scripts

### DIFF
--- a/boringssl-2016-02-12/test-libfuzzer.sh
+++ b/boringssl-2016-02-12/test-libfuzzer.sh
@@ -12,5 +12,5 @@ set -x
 rm -rf $CORPUS
 mkdir $CORPUS
 rm -f *.log
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -use_value_profile=1 -jobs=$JOBS -workers=$JOBS $CORPUS seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -use_value_profile=1 -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS seeds
 grep "AddressSanitizer: heap-use-after-free" fuzz-0.log || exit 1

--- a/c-ares-CVE-2016-5180/test-libfuzzer.sh
+++ b/c-ares-CVE-2016-5180/test-libfuzzer.sh
@@ -3,5 +3,5 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 . $(dirname $0)/../common.sh
 set -x
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -max_total_time=100 2>&1 | tee log
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -max_total_time=100 $LIBFUZZER_FLAGS 2>&1 | tee log
 grep -Pzo "(?s)ERROR: AddressSanitizer:.*ares_create_query" log

--- a/freetype2-2017/test-libfuzzer.sh
+++ b/freetype2-2017/test-libfuzzer.sh
@@ -11,7 +11,7 @@ test_source_location() {
   SRC_LOC="$1"
   echo "test_source_location: $SRC_LOC"
   [ -e $EXECUTABLE_NAME_BASE ] && \
-    ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -exit_on_src_pos=$SRC_LOC -jobs=$JOBS -workers=$JOBS $CORPUS seeds
+    ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -exit_on_src_pos=$SRC_LOC -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS seeds
   grep "INFO: found line matching '$SRC_LOC'" fuzz-*.log || (date && exit 1)
 }
 

--- a/guetzli-2017-3-30/test-libfuzzer.sh
+++ b/guetzli-2017-3-30/test-libfuzzer.sh
@@ -7,5 +7,5 @@ rm -rf $CORPUS
 
 cp -r $SCRIPT_DIR/seeds $CORPUS
 
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -max_len=180 -use_value_profile=1 -close_fd_mask=3 -dict=$SCRIPT_DIR/jpeg.dict -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $CORPUS
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -max_len=180 -use_value_profile=1 -close_fd_mask=3 -dict=$SCRIPT_DIR/jpeg.dict -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS
 grep "ERROR: libFuzzer: deadly signal" fuzz-0.log || exit 1

--- a/harfbuzz-1.3.2/test-libfuzzer.sh
+++ b/harfbuzz-1.3.2/test-libfuzzer.sh
@@ -5,5 +5,5 @@
 set -x
 rm -rf $CORPUS
 mkdir $CORPUS
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -max_total_time=1800 -jobs=$JOBS -workers=$JOBS $CORPUS seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -max_total_time=1800 -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS seeds
 grep "hb-buffer.cc:419: bool hb_buffer_t::move_to(unsigned int): Assertion `i <= out_len + (len - idx)' failed" fuzz-0.log

--- a/json-2017-02-12/test-libfuzzer.sh
+++ b/json-2017-02-12/test-libfuzzer.sh
@@ -6,5 +6,5 @@ set -x
 rm -rf $CORPUS fuzz-*.log
 mkdir -p $CORPUS
 
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $CORPUS seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS seeds
 grep "ERROR: libFuzzer: deadly signal" fuzz-0.log || exit 1

--- a/lcms-2017-03-21/test-libfuzzer.sh
+++ b/lcms-2017-03-21/test-libfuzzer.sh
@@ -6,6 +6,6 @@ set -x
 rm -rf $CORPUS
 mkdir $CORPUS
 
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $CORPUS $SCRIPT_DIR/seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS $SCRIPT_DIR/seeds
 grep 'ERROR: AddressSanitizer: heap-buffer-overflow' fuzz-0.log || exit 1
 

--- a/libarchive-2017-01-04/test-libfuzzer.sh
+++ b/libarchive-2017-01-04/test-libfuzzer.sh
@@ -7,6 +7,6 @@ set -x
 rm -rf $CORPUS
 mkdir $CORPUS
 
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS -max_len=1000 $CORPUS $SCRIPT_DIR/seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS -max_len=1000 $LIBFUZZER_FLAGS $CORPUS $SCRIPT_DIR/seeds
 grep 'ERROR: AddressSanitizer: heap-buffer-overflow' fuzz-0.log || exit 1
 

--- a/libjpeg-turbo-07-2017/test-libfuzzer.sh
+++ b/libjpeg-turbo-07-2017/test-libfuzzer.sh
@@ -13,7 +13,7 @@ test_source_location() {
   echo "test_source_location: $SRC_LOC"
   rm -f *.log
   [ -e $EXECUTABLE_NAME_BASE ] && \
-    ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -exit_on_src_pos=$SRC_LOC -jobs=$JOBS -workers=$JOBS -print_pcs=1 $CORPUS $SCRIPT_DIR/seeds
+    ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -exit_on_src_pos=$SRC_LOC -jobs=$JOBS -workers=$JOBS -print_pcs=1 $LIBFUZZER_FLAGS $CORPUS $SCRIPT_DIR/seeds
   grep "INFO: found line matching '$SRC_LOC'" fuzz-*.log || exit 1
 }
 

--- a/libpng-1.2.56/test-libfuzzer.sh
+++ b/libpng-1.2.56/test-libfuzzer.sh
@@ -15,7 +15,7 @@ test_source_location() {
   rm -f *.log
   # This target has a 2Gb malloc oom, so we have to use rss_limit_mb=3000
   [ -e $EXECUTABLE_NAME_BASE ] && \
-    ./$EXECUTABLE_NAME_BASE -close_fd_mask=3 -artifact_prefix=$CORPUS/ -exit_on_src_pos=$SRC_LOC  -runs=100000000 -jobs=$JOBS -workers=$JOBS $CORPUS $SCRIPT_DIR/seeds -rss_limit_mb=3000
+    ./$EXECUTABLE_NAME_BASE -close_fd_mask=3 -artifact_prefix=$CORPUS/ -exit_on_src_pos=$SRC_LOC  -runs=100000000 -jobs=$JOBS -workers=$JOBS $CORPUS $SCRIPT_DIR/seeds -rss_limit_mb=3000 $LIBFUZZER_FLAGS
   grep "INFO: found line matching '$SRC_LOC'" fuzz-*.log || exit 1
 }
 

--- a/libssh-2017-1272/test-libfuzzer.sh
+++ b/libssh-2017-1272/test-libfuzzer.sh
@@ -9,7 +9,7 @@ mkdir $CORPUS
 
 rm -f *.log
 
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -max_len=60 -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $CORPUS
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -max_len=60 -artifact_prefix=$CORPUS/ -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS
 grep "ERROR: LeakSanitizer: detected memory leaks" fuzz-0.log || exit 1
 
 

--- a/libxml2-v2.9.2/test-libfuzzer.sh
+++ b/libxml2-v2.9.2/test-libfuzzer.sh
@@ -7,5 +7,5 @@ set -x
 get_git_revision https://github.com/mcarpenter/afl be3e88d639da5350603f6c0fee06970128504342 afl
 rm -rf $CORPUS
 mkdir $CORPUS
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -dict=afl/dictionaries/xml.dict -workers=$JOBS $CORPUS -max_len=64
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -jobs=$JOBS -dict=afl/dictionaries/xml.dict -workers=$JOBS $CORPUS -max_len=64 $LIBFUZZER_FLAGS
 grep "AddressSanitizer: heap-buffer-overflow\|ERROR: LeakSanitizer: detected memory leaks" fuzz-0.log

--- a/openssl-1.0.1f/test-libfuzzer.sh
+++ b/openssl-1.0.1f/test-libfuzzer.sh
@@ -4,5 +4,5 @@
 # Find heartbleed.
 . $(dirname $0)/../common.sh
 set -x
-[ -e $EXECUTABLE_NAME_BASE ]  && ./$EXECUTABLE_NAME_BASE -max_total_time=300 -detect_leaks=0 2>&1 | tee log
+[ -e $EXECUTABLE_NAME_BASE ]  && ./$EXECUTABLE_NAME_BASE -max_total_time=300 -detect_leaks=0 $LIBFUZZER_FLAGS 2>&1 | tee log
 grep -Pzo "(?s)ERROR: AddressSanitizer: heap-buffer-overflow.*READ of size.*#1 0x.* in tls1_process_heartbeat .*ssl/t1_lib.c:2586" log

--- a/openssl-1.0.2d/test-libfuzzer.sh
+++ b/openssl-1.0.2d/test-libfuzzer.sh
@@ -13,6 +13,6 @@ grep 'Assertion `strcmp(openssl_results.exptmod, gcrypt_results.exptmod)==0. fai
 # We know that this crasher minimizes to 132 bytes.
 # If we manage to minimize it further the test will fail,
 # but we will learn something new.
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE $SCRIPT_DIR/crash-12ae1af0c82252420b5f780bc9ed48d3ba05109e  -minimize_crash=1 -runs=1000000 2> min.log
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE $SCRIPT_DIR/crash-12ae1af0c82252420b5f780bc9ed48d3ba05109e  -minimize_crash=1 -runs=1000000 $LIBFUZZER_FLAGS 2> min.log
 grep CRASH_MIN min.log
 grep "CRASH_MIN: failed to minimize beyond ./minimized-from-.* (1.. bytes), exiting" min.log || exit 1

--- a/pcre2-10.00/test-libfuzzer.sh
+++ b/pcre2-10.00/test-libfuzzer.sh
@@ -5,5 +5,5 @@
 set -x
 rm -rf $CORPUS
 mkdir $CORPUS
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -max_total_time=300 -jobs=$JOBS -workers=$JOBS $CORPUS
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -max_total_time=300 -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS
 grep "ERROR: AddressSanitizer" fuzz-0.log

--- a/proj4-2017-08-14/test-libfuzzer.sh
+++ b/proj4-2017-08-14/test-libfuzzer.sh
@@ -9,6 +9,6 @@ mkdir $CORPUS
 
 rm fuzz-*.log
 
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS -jobs=$JOBS -workers=$JOBS $CORPUS seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS seeds
 grep "ERROR: LeakSanitizer" fuzz-0.log || exit 1
 

--- a/re2-2014-12-09/test-libfuzzer.sh
+++ b/re2-2014-12-09/test-libfuzzer.sh
@@ -6,7 +6,7 @@ set -x
 rm -rf $CORPUS
 mkdir $CORPUS
 rm -f *.log
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -exit_on_src_pos=re2/dfa.cc:474 -exit_on_src_pos=re2/dfa.cc:474  -runs=10000000 -jobs=$JOBS -workers=$JOBS $CORPUS
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE -artifact_prefix=$CORPUS/ -exit_on_src_pos=re2/dfa.cc:474 -exit_on_src_pos=re2/dfa.cc:474  -runs=10000000 -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS
 grep "INFO: found line matching 're2/dfa.cc:474', exiting." fuzz-0.log || exit 1
 
 # Also test merging here

--- a/woff2-2016-05-06/test-libfuzzer.sh
+++ b/woff2-2016-05-06/test-libfuzzer.sh
@@ -7,7 +7,7 @@ set -x
 # Find the buffer overflow (or OOM) with a seed corpus.
 rm -rf $CORPUS
 mkdir $CORPUS
-[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE  -artifact_prefix=$CORPUS/ -max_total_time=1800 -jobs=$JOBS -workers=$JOBS $CORPUS seeds
+[ -e $EXECUTABLE_NAME_BASE ] && ./$EXECUTABLE_NAME_BASE  -artifact_prefix=$CORPUS/ -max_total_time=1800 -jobs=$JOBS -workers=$JOBS $LIBFUZZER_FLAGS $CORPUS seeds
 grep "AddressSanitizer: heap-buffer-overflow\|ERROR: libFuzzer: out-of-memory" fuzz-0.log  || exit 1
 
 # Find OOM bug with an empty seed corpus.


### PR DESCRIPTION
Not sure if this of any use to anyone other than me, but I found it allows you to easily test libFuzzer variations without hacking shell scripts.