### PR TITLE
Fixed unreachable option in re2.

### DIFF
--- a/re2-2014-12-09/target.cc
+++ b/re2-2014-12-09/target.cc
@@ -5,7 +5,7 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (size < 3 || size > 64) return 0;
-  uint16_t f = (data[0] << 16) + data[1];
+  uint16_t f = (data[0] << 8) + data[1];
   RE2::Options opt;
   opt.set_log_errors(false);
   if (f & 1) opt.set_encoding(RE2::Options::EncodingLatin1);


### PR DESCRIPTION
`data[0] << 16 + data[1]` always results in `0b0000_0000_XXXX_XXXX`, where `XXXX_XXXX` is the bits of `data[1]`. Therefore, `f & 256` to `f & 1024` are meaningless.